### PR TITLE
Fix: for correct processing of circuit and device in the LinkPeer model

### DIFF
--- a/src/annetbox/v37/models.py
+++ b/src/annetbox/v37/models.py
@@ -48,7 +48,10 @@ class Circuit:
 
 
 @dataclass
-class LinkPeer(Entity):
+class LinkPeer:
+    id: int
+    display: str
+    url: str
     cable: int
     device: Entity | None = None
     term_side: str | None = None


### PR DESCRIPTION
adaptix.load_error.NoRequiredFieldsLoadError: fields={'name'}, input_value={'id': 1, 'url': 'http://localhost:8000/api/circuits/circuit-terminations/1/', 'display': 'spine1 --- leaf1: Termination A', 'circuit': {'id': 1, 'url': 'http://localhost:8000/api/circuits/circuits/1/', 'display': 'spine1 --- leaf1', 'cid': 'spine1 --- leaf1'}, 'term_side': 'A', 'cable': 4, '_occupied': True}


  "link_peers": [
      {
          "id": 9,
          "url": "http://localhost:8000/api/dcim/interfaces/9/",
          "display": "GigabitEthernet2/0",
          "device": {
              "id": 3,
              "url": "http://localhost:8000/api/dcim/devices/3/",
              "display": "lab-r2.nh.com",
              "name": "lab-r2.nh.com"
          },
          "name": "GigabitEthernet2/0",
          "cable": 2,
          "_occupied": true
      }
  ],

  "link_peers": [
      {
          "id": 1,
          "url": "http://localhost:8000/api/circuits/circuit-terminations/1/",
          "display": "spine1 --- leaf1: Termination A",
          "circuit": {
              "id": 1,
              "url": "http://localhost:8000/api/circuits/circuits/1/",
              "display": "spine1 --- leaf1",
              "cid": "spine1 --- leaf1"
          },
          "term_side": "A",
          "cable": 4,
          "_occupied": true
      }
  ],