### PR TITLE
Refactor Device model in v41 and v42: Replace DeviceRole with Entity based on PR annetutil/annet#260 comment

### DIFF
--- a/src/annetbox/v41/models.py
+++ b/src/annetbox/v41/models.py
@@ -46,12 +46,6 @@ class DeviceIp:
 
 
 @dataclass
-class DeviceRole:
-    id: int
-    url: str
-
-
-@dataclass
 class Circuit:
     id: int
     url: str
@@ -143,7 +137,7 @@ class Device(Entity):
     url: str
     display: str  # renamed in 3.x from display_name
     device_type: DeviceType
-    role: DeviceRole  # device_role is depricated after 4.0
+    role: Entity  # device_role is depricated after 4.0
     tenant: EntityWithSlug | None
     platform: Entity | None
     serial: str

--- a/src/annetbox/v42/models.py
+++ b/src/annetbox/v42/models.py
@@ -46,12 +46,6 @@ class DeviceIp:
 
 
 @dataclass
-class DeviceRole:
-    id: int
-    url: str
-
-
-@dataclass
 class Circuit:
     id: int
     url: str
@@ -143,7 +137,7 @@ class Device(Entity):
     url: str
     display: str  # renamed in 3.x from display_name
     device_type: DeviceType
-    role: DeviceRole  # device_role is depricated after 4.0
+    role: Entity  # device_role is depricated after 4.0
     tenant: EntityWithSlug | None
     platform: Entity | None
     serial: str


### PR DESCRIPTION
## Description
Refactor `role` in `Device` model for v41 and v42: replacing `DeviceRole` with `Entity` based on the comment in PR:

- annetutil/annet#260 (see comment: https://github.com/annetutil/annet/pull/260#discussion_r1967435182)