### PR TITLE
fix: update cable type to InterfaceCable in v4 model

### DIFF
--- a/src/annetbox/v41/models.py
+++ b/src/annetbox/v41/models.py
@@ -54,22 +54,22 @@ class Circuit:
 
 
 @dataclass
-class LinkPeer:
-    id: int
-    display: str
-    url: str
-    cable: int
-    device: Entity | None = None
-    term_side: str | None = None
-    circuit: Circuit | None = None
-
-
-@dataclass
 class InterfaceCable:
     id: int
     label: str
     display: str
     url: str
+
+
+@dataclass
+class LinkPeer:
+    id: int
+    display: str
+    url: str
+    cable: InterfaceCable # after 4.0 `int` deprecated
+    device: Entity | None = None
+    term_side: str | None = None
+    circuit: Circuit | None = None
 
 
 @dataclass
@@ -81,7 +81,7 @@ class InterfaceType:
 @dataclass
 class InterfaceConnectedEndpoint(Entity):
     device: Entity
-    cable: int
+    cable: InterfaceCable # after 4.0 `int` deprecated
 
 
 @dataclass

--- a/src/annetbox/v41/models.py
+++ b/src/annetbox/v41/models.py
@@ -66,7 +66,7 @@ class LinkPeer:
     id: int
     display: str
     url: str
-    cable: InterfaceCable # after 4.0 `int` deprecated
+    cable: InterfaceCable
     device: Entity | None = None
     term_side: str | None = None
     circuit: Circuit | None = None
@@ -81,7 +81,7 @@ class InterfaceType:
 @dataclass
 class InterfaceConnectedEndpoint(Entity):
     device: Entity
-    cable: InterfaceCable # after 4.0 `int` deprecated
+    cable: InterfaceCable
 
 
 @dataclass

--- a/src/annetbox/v42/models.py
+++ b/src/annetbox/v42/models.py
@@ -54,22 +54,22 @@ class Circuit:
 
 
 @dataclass
-class LinkPeer:
-    id: int
-    display: str
-    url: str
-    cable: int
-    device: Entity | None = None
-    term_side: str | None = None
-    circuit: Circuit | None = None
-
-
-@dataclass
 class InterfaceCable:
     id: int
     label: str
     display: str
     url: str
+
+
+@dataclass
+class LinkPeer:
+    id: int
+    display: str
+    url: str
+    cable: InterfaceCable # after 4.0 `int` deprecated
+    device: Entity | None = None
+    term_side: str | None = None
+    circuit: Circuit | None = None
 
 
 @dataclass
@@ -81,7 +81,7 @@ class InterfaceType:
 @dataclass
 class InterfaceConnectedEndpoint(Entity):
     device: Entity
-    cable: int
+    cable: InterfaceCable # after 4.0 `int` deprecated
 
 
 @dataclass

--- a/src/annetbox/v42/models.py
+++ b/src/annetbox/v42/models.py
@@ -66,7 +66,7 @@ class LinkPeer:
     id: int
     display: str
     url: str
-    cable: InterfaceCable # after 4.0 `int` deprecated
+    cable: InterfaceCable
     device: Entity | None = None
     term_side: str | None = None
     circuit: Circuit | None = None
@@ -81,7 +81,7 @@ class InterfaceType:
 @dataclass
 class InterfaceConnectedEndpoint(Entity):
     device: Entity
-    cable: InterfaceCable # after 4.0 `int` deprecated
+    cable: InterfaceCable
 
 
 @dataclass


### PR DESCRIPTION
## Description:
Changed `cable` field type in `LinkPeer` and `InterfaceConnectedEndpoint` classes.from `int` to `InterfaceCable`.
Moved the InterfaceCable class definition above the models that reference it for proper usage.

### Reason for change  
It was not possible to find an explicit mention of this change in the NetBox release notes. However, in NetBox **3.7**, the `cable` field in `link_peers` and `connected_endpoints` was an `int`, like:
3.7
```json
"link_peers": [
    {
        "cable": 1
    }
]
```
4.1
```json
"link_peers": [
    {
        "cable": {
            "id": 1,
            "url": "http://192.168.2.128:8000/api/dcim/cables/1/",
            "display": "#1",
            "label": "",
            "description": ""
        }
    }
]
```
The same change was applied to the `connected_endpoints` field, where the cable field also changed from int to an InterfaceCable object.


### Related PR
- annetutil/annet#260