### PR TITLE
rollback of #52

### DIFF
--- a/src/annetbox/v41/models.py
+++ b/src/annetbox/v41/models.py
@@ -24,9 +24,11 @@ class Label:
 
 
 @dataclass
-class DeviceType(EntityWithSlug):
+class DeviceType:
+    id: int
     manufacturer: EntityWithSlug
     model: str
+    slug: str
 
 
 @dataclass


### PR DESCRIPTION
there is no "name" field in REST model. https://github.com/annetutil/annetbox/pull/52 need to be rolled back.