### PR TITLE
Adding new parameters ro `all_hosts_filter` filter

### DIFF
--- a/src/annetbox/v37/client_async.py
+++ b/src/annetbox/v37/client_async.py
@@ -167,9 +167,9 @@ class NetboxV37(BaseNetboxClient):
         tenant: list[str] | None = None,
         status: list[str] | None = None,
         asset_tag: list[str] | None = None,
-        has_oob_ip: list[str] | None = None,
-        has_primary_ip: list[str] | None = None,
-        location_id: list[str] | None = None,
+        has_oob_ip: bool | None = None,
+        has_primary_ip: bool | None = None,
+        location_id: list[int] | None = None,
         limit: int = 20,
         offset: int = 0,
     ) -> PagingResponse[Entity]:

--- a/src/annetbox/v37/client_async.py
+++ b/src/annetbox/v37/client_async.py
@@ -169,7 +169,7 @@ class NetboxV37(BaseNetboxClient):
         asset_tag: list[str] | None = None,
         has_oob_ip: list[str] | None = None,
         has_primary_ip: list[str] | None = None,
-        location_id:  list[str] | None = None,
+        location_id: list[str] | None = None,
         limit: int = 20,
         offset: int = 0,
     ) -> PagingResponse[Entity]:

--- a/src/annetbox/v37/client_async.py
+++ b/src/annetbox/v37/client_async.py
@@ -167,6 +167,9 @@ class NetboxV37(BaseNetboxClient):
         tenant: list[str] | None = None,
         status: list[str] | None = None,
         asset_tag: list[str] | None = None,
+        has_oob_ip: list[str] | None = None,
+        has_primary_ip: list[str] | None = None,
+        location_id:  list[str] | None = None,
         limit: int = 20,
         offset: int = 0,
     ) -> PagingResponse[Entity]:

--- a/src/annetbox/v37/client_sync.py
+++ b/src/annetbox/v37/client_sync.py
@@ -167,9 +167,9 @@ class NetboxV37(BaseNetboxClient):
         tenant: list[str] | None = None,
         status: list[str] | None = None,
         asset_tag: list[str] | None = None,
-        has_oob_ip: list[str] | None = None,
-        has_primary_ip: list[str] | None = None,
-        location_id: list[str] | None = None,
+        has_oob_ip: bool | None = None,
+        has_primary_ip: bool | None = None,
+        location_id: list[int] | None = None,
         limit: int = 20,
         offset: int = 0,
     ) -> PagingResponse[Entity]:

--- a/src/annetbox/v37/client_sync.py
+++ b/src/annetbox/v37/client_sync.py
@@ -169,7 +169,7 @@ class NetboxV37(BaseNetboxClient):
         asset_tag: list[str] | None = None,
         has_oob_ip: list[str] | None = None,
         has_primary_ip: list[str] | None = None,
-        location_id:  list[str] | None = None,
+        location_id: list[str] | None = None,
         limit: int = 20,
         offset: int = 0,
     ) -> PagingResponse[Entity]:

--- a/src/annetbox/v37/client_sync.py
+++ b/src/annetbox/v37/client_sync.py
@@ -167,6 +167,9 @@ class NetboxV37(BaseNetboxClient):
         tenant: list[str] | None = None,
         status: list[str] | None = None,
         asset_tag: list[str] | None = None,
+        has_oob_ip: list[str] | None = None,
+        has_primary_ip: list[str] | None = None,
+        location_id:  list[str] | None = None,
         limit: int = 20,
         offset: int = 0,
     ) -> PagingResponse[Entity]:

--- a/src/annetbox/v41/client_async.py
+++ b/src/annetbox/v41/client_async.py
@@ -165,6 +165,9 @@ class NetboxV41(BaseNetboxClient):
         tenant: list[str] | None = None,
         status: list[str] | None = None,
         asset_tag: list[str] | None = None,
+        has_oob_ip: list[str] | None = None,
+        has_primary_ip: list[str] | None = None,
+        location_id:  list[str] | None = None,
         limit: int = 20,
         offset: int = 0,
     ) -> PagingResponse[Entity]:

--- a/src/annetbox/v41/client_async.py
+++ b/src/annetbox/v41/client_async.py
@@ -167,7 +167,7 @@ class NetboxV41(BaseNetboxClient):
         asset_tag: list[str] | None = None,
         has_oob_ip: list[str] | None = None,
         has_primary_ip: list[str] | None = None,
-        location_id:  list[str] | None = None,
+        location_id: list[str] | None = None,
         limit: int = 20,
         offset: int = 0,
     ) -> PagingResponse[Entity]:

--- a/src/annetbox/v41/client_async.py
+++ b/src/annetbox/v41/client_async.py
@@ -165,9 +165,9 @@ class NetboxV41(BaseNetboxClient):
         tenant: list[str] | None = None,
         status: list[str] | None = None,
         asset_tag: list[str] | None = None,
-        has_oob_ip: list[str] | None = None,
-        has_primary_ip: list[str] | None = None,
-        location_id: list[str] | None = None,
+        has_oob_ip: bool | None = None,
+        has_primary_ip: bool | None = None,
+        location_id: list[int] | None = None,
         limit: int = 20,
         offset: int = 0,
     ) -> PagingResponse[Entity]:

--- a/src/annetbox/v41/client_sync.py
+++ b/src/annetbox/v41/client_sync.py
@@ -167,9 +167,9 @@ class NetboxV41(BaseNetboxClient):
         tenant: list[str] | None = None,
         status: list[str] | None = None,
         asset_tag: list[str] | None = None,
-        has_oob_ip: list[str] | None = None,
-        has_primary_ip: list[str] | None = None,
-        location_id: list[str] | None = None,
+        has_oob_ip: bool | None = None,
+        has_primary_ip: bool | None = None,
+        location_id: list[int] | None = None,
         limit: int = 20,
         offset: int = 0,
     ) -> PagingResponse[Entity]:

--- a/src/annetbox/v41/client_sync.py
+++ b/src/annetbox/v41/client_sync.py
@@ -48,7 +48,9 @@ class NetboxV41(BaseNetboxClient):
     ) -> PagingResponse[Interface]:
         pass
 
-    dcim_all_interfaces = collect(dcim_interfaces, field="device_id")
+    dcim_all_interfaces = collect(
+        dcim_interfaces, field="device_id", batch_size=10,  # heavy request
+    )
     dcim_all_interfaces_by_id = collect(dcim_interfaces, field="id")
 
     @get("dcim/interfaces/{id}/")
@@ -167,7 +169,7 @@ class NetboxV41(BaseNetboxClient):
         asset_tag: list[str] | None = None,
         has_oob_ip: list[str] | None = None,
         has_primary_ip: list[str] | None = None,
-        location_id:  list[str] | None = None,
+        location_id: list[str] | None = None,
         limit: int = 20,
         offset: int = 0,
     ) -> PagingResponse[Entity]:

--- a/src/annetbox/v41/client_sync.py
+++ b/src/annetbox/v41/client_sync.py
@@ -48,9 +48,7 @@ class NetboxV41(BaseNetboxClient):
     ) -> PagingResponse[Interface]:
         pass
 
-    dcim_all_interfaces = collect(
-        dcim_interfaces, field="device_id", batch_size=10,  # heavy request
-    )
+    dcim_all_interfaces = collect(dcim_interfaces, field="device_id")
     dcim_all_interfaces_by_id = collect(dcim_interfaces, field="id")
 
     @get("dcim/interfaces/{id}/")
@@ -167,6 +165,9 @@ class NetboxV41(BaseNetboxClient):
         tenant: list[str] | None = None,
         status: list[str] | None = None,
         asset_tag: list[str] | None = None,
+        has_oob_ip: list[str] | None = None,
+        has_primary_ip: list[str] | None = None,
+        location_id:  list[str] | None = None,
         limit: int = 20,
         offset: int = 0,
     ) -> PagingResponse[Entity]:

--- a/src/annetbox/v42/client_async.py
+++ b/src/annetbox/v42/client_async.py
@@ -169,7 +169,7 @@ class NetboxV42(BaseNetboxClient):
         asset_tag: list[str] | None = None,
         has_oob_ip: list[str] | None = None,
         has_primary_ip: list[str] | None = None,
-        location_id:  list[str] | None = None,
+        location_id: list[str] | None = None,
         limit: int = 20,
         offset: int = 0,
     ) -> PagingResponse[Entity]:

--- a/src/annetbox/v42/client_async.py
+++ b/src/annetbox/v42/client_async.py
@@ -167,9 +167,9 @@ class NetboxV42(BaseNetboxClient):
         tenant: list[str] | None = None,
         status: list[str] | None = None,
         asset_tag: list[str] | None = None,
-        has_oob_ip: list[str] | None = None,
-        has_primary_ip: list[str] | None = None,
-        location_id: list[str] | None = None,
+        has_oob_ip: bool | None = None,
+        has_primary_ip: bool | None = None,
+        location_id: list[int] | None = None,
         limit: int = 20,
         offset: int = 0,
     ) -> PagingResponse[Entity]:

--- a/src/annetbox/v42/client_async.py
+++ b/src/annetbox/v42/client_async.py
@@ -167,6 +167,9 @@ class NetboxV42(BaseNetboxClient):
         tenant: list[str] | None = None,
         status: list[str] | None = None,
         asset_tag: list[str] | None = None,
+        has_oob_ip: list[str] | None = None,
+        has_primary_ip: list[str] | None = None,
+        location_id:  list[str] | None = None,
         limit: int = 20,
         offset: int = 0,
     ) -> PagingResponse[Entity]:

--- a/src/annetbox/v42/client_sync.py
+++ b/src/annetbox/v42/client_sync.py
@@ -169,9 +169,9 @@ class NetboxV42(BaseNetboxClient):
         tenant: list[str] | None = None,
         status: list[str] | None = None,
         asset_tag: list[str] | None = None,
-        has_oob_ip: list[str] | None = None,
-        has_primary_ip: list[str] | None = None,
-        location_id: list[str] | None = None,
+        has_oob_ip: bool | None = None,
+        has_primary_ip: bool | None = None,
+        location_id: list[int] | None = None,
         limit: int = 20,
         offset: int = 0,
     ) -> PagingResponse[Entity]:

--- a/src/annetbox/v42/client_sync.py
+++ b/src/annetbox/v42/client_sync.py
@@ -50,9 +50,7 @@ class NetboxV42(BaseNetboxClient):
     ) -> PagingResponse[Interface]:
         pass
 
-    dcim_all_interfaces = collect(
-        dcim_interfaces, field="device_id", batch_size=10,  # heavy request
-    )
+    dcim_all_interfaces = collect(dcim_interfaces, field="device_id")
     dcim_all_interfaces_by_id = collect(dcim_interfaces, field="id")
 
     @get("dcim/interfaces/{id}/")
@@ -169,6 +167,9 @@ class NetboxV42(BaseNetboxClient):
         tenant: list[str] | None = None,
         status: list[str] | None = None,
         asset_tag: list[str] | None = None,
+        has_oob_ip: list[str] | None = None,
+        has_primary_ip: list[str] | None = None,
+        location_id:  list[str] | None = None,
         limit: int = 20,
         offset: int = 0,
     ) -> PagingResponse[Entity]:

--- a/src/annetbox/v42/client_sync.py
+++ b/src/annetbox/v42/client_sync.py
@@ -50,7 +50,9 @@ class NetboxV42(BaseNetboxClient):
     ) -> PagingResponse[Interface]:
         pass
 
-    dcim_all_interfaces = collect(dcim_interfaces, field="device_id")
+    dcim_all_interfaces = collect(
+        dcim_interfaces, field="device_id", batch_size=10,  # heavy request
+    )
     dcim_all_interfaces_by_id = collect(dcim_interfaces, field="id")
 
     @get("dcim/interfaces/{id}/")
@@ -169,7 +171,7 @@ class NetboxV42(BaseNetboxClient):
         asset_tag: list[str] | None = None,
         has_oob_ip: list[str] | None = None,
         has_primary_ip: list[str] | None = None,
-        location_id:  list[str] | None = None,
+        location_id: list[str] | None = None,
         limit: int = 20,
         offset: int = 0,
     ) -> PagingResponse[Entity]:


### PR DESCRIPTION
... has_oob_ip, has_primary_ip, location_id

Value of `location_id` must be int

Example:
```yaml
storage:
  netbox:
    adapter: netbox
    params:
      ...
      all_hosts_filter:
        has_primary_ip: [true]
        has_oob_ip: [false]
        location_id: [3]
```