### PR TITLE
Add vrf info

### DIFF
--- a/src/annetbox/v37/models.py
+++ b/src/annetbox/v37/models.py
@@ -90,6 +90,11 @@ class InterfaceVlan(Entity):
 
 
 @dataclass
+class Vrf(Entity):
+    rd: str
+    description: str
+
+@dataclass
 class Interface(Entity):
     cable: InterfaceCable | None
     cable_end: str
@@ -106,7 +111,7 @@ class Interface(Entity):
     tagged_vlans: list[InterfaceVlan] | None
     created: datetime
     last_updated: datetime
-    vrf: Entity | None
+    vrf: Vrf | None
     mgmt_only: bool
     lag: Entity | None
     mtu: int | None
@@ -186,7 +191,7 @@ class IpAddress:
     created: datetime
     last_updated: datetime
     tenant: EntityWithSlug | None
-    vrf: Entity | None
+    vrf: Vrf | None
 
 
 class CableType(str, Enum):
@@ -271,7 +276,7 @@ class Prefix:
     id: int
     prefix: str
     site: Entity | None
-    vrf: Entity | None
+    vrf: Vrf | None
     tenant: Entity | None
     vlan: Entity | None
     role: Entity | None

--- a/src/annetbox/v41/models.py
+++ b/src/annetbox/v41/models.py
@@ -96,6 +96,12 @@ class InterfaceVlan(Entity):
 
 
 @dataclass
+class Vrf(Entity):
+    rd: str
+    description: str
+
+
+@dataclass
 class Interface(Entity):
     cable: InterfaceCable | None
     cable_end: str
@@ -112,7 +118,7 @@ class Interface(Entity):
     tagged_vlans: list[InterfaceVlan] | None
     created: datetime
     last_updated: datetime
-    vrf: Entity | None
+    vrf: Vrf | None
     mgmt_only: bool
     lag: Entity | None
     mtu: int | None
@@ -185,7 +191,7 @@ class IpAddress:
     created: datetime
     last_updated: datetime
     tenant: EntityWithSlug | None
-    vrf: Entity | None
+    vrf: Vrf | None
 
 
 class CableType(str, Enum):
@@ -270,7 +276,7 @@ class Prefix:
     id: int
     prefix: str
     site: Entity | None
-    vrf: Entity | None
+    vrf: Vrf | None
     tenant: Entity | None
     vlan: Entity | None
     role: Entity | None

--- a/src/annetbox/v42/models.py
+++ b/src/annetbox/v42/models.py
@@ -96,6 +96,11 @@ class InterfaceVlan(Entity):
 
 
 @dataclass
+class Vrf(Entity):
+    rd: str
+    description: str
+
+@dataclass
 class Interface(Entity):
     cable: InterfaceCable | None
     cable_end: str | None  # was an empty string, now None
@@ -112,7 +117,7 @@ class Interface(Entity):
     tagged_vlans: list[InterfaceVlan] | None
     created: datetime
     last_updated: datetime
-    vrf: Entity | None
+    vrf: Vrf | None
     mgmt_only: bool
     lag: Entity | None
     mtu: int | None
@@ -185,7 +190,7 @@ class IpAddress:
     created: datetime
     last_updated: datetime
     tenant: EntityWithSlug | None
-    vrf: Entity | None
+    vrf: Vrf | None
 
 
 class CableType(str, Enum):
@@ -271,7 +276,7 @@ class Prefix:
     prefix: str
     scope_type: str | None
     scope: Entity | None  # site is depricated after 4.2
-    vrf: Entity | None
+    vrf: Vrf | None
     tenant: Entity | None
     vlan: Entity | None
     role: Entity | None


### PR DESCRIPTION
Add rd and description info to vrf model
Before:
```
vrf=Entity(id=100, name='internet', display='internet (12345:1)', url='https://netbox.example.ru/api/ipam/vrfs/100/'),
```

After:
```
vrf=Vrf(id=100, name='internet', display='internet (12345:1)', url='https://netbox.example.ru/api/ipam/vrfs/100/', rd='12345:1', description='to internet'),
```