### PR TITLE
Add Site model and dcim_site/dcim_sites/dcim_all_sites client methods

### DIFF
--- a/src/annetbox/v37/client_async.py
+++ b/src/annetbox/v37/client_async.py
@@ -21,6 +21,7 @@ from .models import (
     ItemToDelete,
     NewCable,
     Prefix,
+    Site,
     TraceTuple,
 )
 
@@ -198,6 +199,29 @@ class NetboxV37(BaseNetboxClient):
         self,
         device_id: int,
     ) -> Device:
+        pass
+
+    @get("dcim/sites/")
+    async def dcim_sites(
+        self,
+        name: list[str] | None = None,
+        slug: list[str] | None = None,
+        id: list[int] | None = None,
+        region: list[str] | None = None,
+        group: list[str] | None = None,
+        tenant: list[str] | None = None,
+        status: list[str] | None = None,
+        tag: list[str] | None = None,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> PagingResponse[Site]:
+        pass
+
+    dcim_all_sites = collect(dcim_sites)
+    dcim_all_sites_by_id = collect(dcim_sites, field="id")
+
+    @get("dcim/sites/{site_id}/")
+    async def dcim_site(self, site_id: int) -> Site:
         pass
 
     # ipam

--- a/src/annetbox/v37/client_sync.py
+++ b/src/annetbox/v37/client_sync.py
@@ -21,6 +21,7 @@ from .models import (
     ItemToDelete,
     NewCable,
     Prefix,
+    Site,
     TraceTuple,
 )
 
@@ -198,6 +199,29 @@ class NetboxV37(BaseNetboxClient):
         self,
         device_id: int,
     ) -> Device:
+        pass
+
+    @get("dcim/sites/")
+    def dcim_sites(
+        self,
+        name: list[str] | None = None,
+        slug: list[str] | None = None,
+        id: list[int] | None = None,
+        region: list[str] | None = None,
+        group: list[str] | None = None,
+        tenant: list[str] | None = None,
+        status: list[str] | None = None,
+        tag: list[str] | None = None,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> PagingResponse[Site]:
+        pass
+
+    dcim_all_sites = collect(dcim_sites)
+    dcim_all_sites_by_id = collect(dcim_sites, field="id")
+
+    @get("dcim/sites/{site_id}/")
+    def dcim_site(self, site_id: int) -> Site:
         pass
 
     # ipam

--- a/src/annetbox/v37/models.py
+++ b/src/annetbox/v37/models.py
@@ -137,6 +137,15 @@ class ConsolePort(Entity):
 
 
 @dataclass
+class Site(Entity):
+    slug: str
+    status: Label
+    custom_fields: dict[str, Any]
+    created: datetime
+    last_updated: datetime
+
+
+@dataclass
 class Device(Entity):
     url: str
     display: str  # renamed in 3.x from display_name

--- a/src/annetbox/v41/client_async.py
+++ b/src/annetbox/v41/client_async.py
@@ -21,6 +21,7 @@ from .models import (
     ItemToDelete,
     NewCable,
     Prefix,
+    Site,
     TraceTuple,
 )
 
@@ -198,6 +199,29 @@ class NetboxV41(BaseNetboxClient):
         self,
         device_id: int,
     ) -> Device:
+        pass
+
+    @get("dcim/sites/")
+    async def dcim_sites(
+        self,
+        name: list[str] | None = None,
+        slug: list[str] | None = None,
+        id: list[int] | None = None,
+        region: list[str] | None = None,
+        group: list[str] | None = None,
+        tenant: list[str] | None = None,
+        status: list[str] | None = None,
+        tag: list[str] | None = None,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> PagingResponse[Site]:
+        pass
+
+    dcim_all_sites = collect(dcim_sites)
+    dcim_all_sites_by_id = collect(dcim_sites, field="id")
+
+    @get("dcim/sites/{site_id}/")
+    async def dcim_site(self, site_id: int) -> Site:
         pass
 
     # ipam

--- a/src/annetbox/v41/client_sync.py
+++ b/src/annetbox/v41/client_sync.py
@@ -21,6 +21,7 @@ from .models import (
     ItemToDelete,
     NewCable,
     Prefix,
+    Site,
     TraceTuple,
 )
 
@@ -198,6 +199,29 @@ class NetboxV41(BaseNetboxClient):
         self,
         device_id: int,
     ) -> Device:
+        pass
+
+    @get("dcim/sites/")
+    def dcim_sites(
+        self,
+        name: list[str] | None = None,
+        slug: list[str] | None = None,
+        id: list[int] | None = None,
+        region: list[str] | None = None,
+        group: list[str] | None = None,
+        tenant: list[str] | None = None,
+        status: list[str] | None = None,
+        tag: list[str] | None = None,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> PagingResponse[Site]:
+        pass
+
+    dcim_all_sites = collect(dcim_sites)
+    dcim_all_sites_by_id = collect(dcim_sites, field="id")
+
+    @get("dcim/sites/{site_id}/")
+    def dcim_site(self, site_id: int) -> Site:
         pass
 
     # ipam

--- a/src/annetbox/v41/models.py
+++ b/src/annetbox/v41/models.py
@@ -144,6 +144,15 @@ class ConsolePort(Entity):
 
 
 @dataclass
+class Site(Entity):
+    slug: str
+    status: Label
+    custom_fields: dict[str, Any]
+    created: datetime
+    last_updated: datetime
+
+
+@dataclass
 class Device(Entity):
     url: str
     display: str  # renamed in 3.x from display_name

--- a/src/annetbox/v42/client_async.py
+++ b/src/annetbox/v42/client_async.py
@@ -21,6 +21,7 @@ from .models import (
     ItemToDelete,
     NewCable,
     Prefix,
+    Site,
     TraceTuple,
     Vlan,
     Vrf,
@@ -200,6 +201,29 @@ class NetboxV42(BaseNetboxClient):
         self,
         device_id: int,
     ) -> Device:
+        pass
+
+    @get("dcim/sites/")
+    async def dcim_sites(
+        self,
+        name: list[str] | None = None,
+        slug: list[str] | None = None,
+        id: list[int] | None = None,
+        region: list[str] | None = None,
+        group: list[str] | None = None,
+        tenant: list[str] | None = None,
+        status: list[str] | None = None,
+        tag: list[str] | None = None,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> PagingResponse[Site]:
+        pass
+
+    dcim_all_sites = collect(dcim_sites)
+    dcim_all_sites_by_id = collect(dcim_sites, field="id")
+
+    @get("dcim/sites/{site_id}/")
+    async def dcim_site(self, site_id: int) -> Site:
         pass
 
     # ipam

--- a/src/annetbox/v42/client_sync.py
+++ b/src/annetbox/v42/client_sync.py
@@ -21,6 +21,7 @@ from .models import (
     ItemToDelete,
     NewCable,
     Prefix,
+    Site,
     TraceTuple,
     Vlan,
     Vrf,
@@ -200,6 +201,29 @@ class NetboxV42(BaseNetboxClient):
         self,
         device_id: int,
     ) -> Device:
+        pass
+
+    @get("dcim/sites/")
+    def dcim_sites(
+        self,
+        name: list[str] | None = None,
+        slug: list[str] | None = None,
+        id: list[int] | None = None,
+        region: list[str] | None = None,
+        group: list[str] | None = None,
+        tenant: list[str] | None = None,
+        status: list[str] | None = None,
+        tag: list[str] | None = None,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> PagingResponse[Site]:
+        pass
+
+    dcim_all_sites = collect(dcim_sites)
+    dcim_all_sites_by_id = collect(dcim_sites, field="id")
+
+    @get("dcim/sites/{site_id}/")
+    def dcim_site(self, site_id: int) -> Site:
         pass
 
     # ipam

--- a/src/annetbox/v42/models.py
+++ b/src/annetbox/v42/models.py
@@ -143,6 +143,15 @@ class ConsolePort(Entity):
 
 
 @dataclass
+class Site(Entity):
+    slug: str
+    status: Label
+    custom_fields: dict[str, Any]
+    created: datetime
+    last_updated: datetime
+
+
+@dataclass
 class Device(Entity):
     url: str
     display: str  # renamed in 3.x from display_name

--- a/tests/integration/definitions.yaml
+++ b/tests/integration/definitions.yaml
@@ -47,6 +47,21 @@ tests:
         args: {limit: 5}
         extract: results[0].id
 
+  - id: dcim_sites_01
+    method: dcim_sites
+    versions: ["v37", "v41", "v42"]
+    args:
+      limit: 5
+
+  - id: dcim_site_01
+    method: dcim_site
+    versions: ["v37", "v41", "v42"]
+    args:
+      site_id: !from_call
+        call: dcim_sites
+        args: {limit: 5}
+        extract: results[0].id
+
   - id: ipam_ip_addresses_01
     method: ipam_ip_addresses
     versions: ["v37", "v41", "v42"]

--- a/tests/integration/fixtures/v37/dcim_site_01/cassette.yaml
+++ b/tests/integration/fixtures/v37/dcim_site_01/cassette.yaml
@@ -1,0 +1,98 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.33.1
+    method: GET
+    uri: http://localhost:8037/api/dcim/sites/?limit=5&offset=0
+  response:
+    body:
+      string: '{"count":24,"next":"http://localhost:8037/api/dcim/sites/?limit=5&offset=5","previous":null,"results":[{"id":24,"url":"http://localhost:8037/api/dcim/sites/24/","display":"Butler
+        Communications","name":"Butler Communications","slug":"ncsu-128","status":{"value":"active","label":"Active"},"region":{"id":40,"url":"http://localhost:8037/api/dcim/regions/40/","display":"North
+        Carolina","name":"North Carolina","slug":"us-nc","_depth":2},"group":null,"tenant":{"id":13,"url":"http://localhost:8037/api/tenancy/tenants/13/","display":"NC
+        State University","name":"NC State University","slug":"nc-state"},"facility":"BUT","time_zone":null,"description":"","physical_address":"3210
+        Faucette Dr., Raleigh, NC 27607","shipping_address":"","latitude":null,"longitude":null,"comments":"","asns":[],"tags":[{"id":7,"url":"http://localhost:8037/api/extras/tags/7/","display":"Golf","name":"Golf","slug":"golf","color":"673ab7"},{"id":12,"url":"http://localhost:8037/api/extras/tags/12/","display":"Lima","name":"Lima","slug":"lima","color":"009688"},{"id":24,"url":"http://localhost:8037/api/extras/tags/24/","display":"X-ray","name":"X-ray","slug":"x-ray","color":"9e9e9e"}],"custom_fields":{},"created":"2021-04-02T00:00:00Z","last_updated":"2021-12-30T15:45:37.371000Z","circuit_count":1,"device_count":2,"prefix_count":0,"rack_count":1,"virtualmachine_count":0,"vlan_count":0},{"id":22,"url":"http://localhost:8037/api/dcim/sites/22/","display":"D.
+        S. Weaver Labs","name":"D. S. Weaver Labs","slug":"ncsu-117","status":{"value":"active","label":"Active"},"region":{"id":40,"url":"http://localhost:8037/api/dcim/regions/40/","display":"North
+        Carolina","name":"North Carolina","slug":"us-nc","_depth":2},"group":null,"tenant":{"id":13,"url":"http://localhost:8037/api/tenancy/tenants/13/","display":"NC
+        State University","name":"NC State University","slug":"nc-state"},"facility":"DSW","time_zone":null,"description":"","physical_address":"3110
+        Faucette Dr., Raleigh, NC 27607","shipping_address":"","latitude":null,"longitude":null,"comments":"","asns":[],"tags":[{"id":17,"url":"http://localhost:8037/api/extras/tags/17/","display":"Quebec","name":"Quebec","slug":"quebec","color":"cddc39"},{"id":20,"url":"http://localhost:8037/api/extras/tags/20/","display":"Tango","name":"Tango","slug":"tango","color":"ff9800"},{"id":24,"url":"http://localhost:8037/api/extras/tags/24/","display":"X-ray","name":"X-ray","slug":"x-ray","color":"9e9e9e"}],"custom_fields":{},"created":"2021-04-02T00:00:00Z","last_updated":"2021-12-30T15:45:37.549000Z","circuit_count":1,"device_count":2,"prefix_count":0,"rack_count":1,"virtualmachine_count":0,"vlan_count":0},{"id":2,"url":"http://localhost:8037/api/dcim/sites/2/","display":"DM-Akron","name":"DM-Akron","slug":"dm-akron","status":{"value":"active","label":"Active"},"region":{"id":51,"url":"http://localhost:8037/api/dcim/regions/51/","display":"Ohio","name":"Ohio","slug":"us-oh","_depth":2},"group":{"id":2,"url":"http://localhost:8037/api/dcim/site-groups/2/","display":"Branch
+        Offices","name":"Branch Offices","slug":"branch-offices","_depth":1},"tenant":{"id":5,"url":"http://localhost:8037/api/tenancy/tenants/5/","display":"Dunder-Mifflin,
+        Inc.","name":"Dunder-Mifflin, Inc.","slug":"dunder-mifflin"},"facility":"","time_zone":null,"description":"","physical_address":"","shipping_address":"","latitude":null,"longitude":null,"comments":"","asns":[],"tags":[{"id":1,"url":"http://localhost:8037/api/extras/tags/1/","display":"Alpha","name":"Alpha","slug":"alpha","color":"aa1409"},{"id":2,"url":"http://localhost:8037/api/extras/tags/2/","display":"Bravo","name":"Bravo","slug":"bravo","color":"f44336"},{"id":7,"url":"http://localhost:8037/api/extras/tags/7/","display":"Golf","name":"Golf","slug":"golf","color":"673ab7"}],"custom_fields":{},"created":"2020-12-19T00:00:00Z","last_updated":"2021-12-30T15:45:37.384000Z","circuit_count":2,"device_count":4,"prefix_count":5,"rack_count":1,"virtualmachine_count":0,"vlan_count":3},{"id":3,"url":"http://localhost:8037/api/dcim/sites/3/","display":"DM-Albany","name":"DM-Albany","slug":"dm-albany","status":{"value":"active","label":"Active"},"region":{"id":43,"url":"http://localhost:8037/api/dcim/regions/43/","display":"New
+        York","name":"New York","slug":"us-ny","_depth":2},"group":{"id":2,"url":"http://localhost:8037/api/dcim/site-groups/2/","display":"Branch
+        Offices","name":"Branch Offices","slug":"branch-offices","_depth":1},"tenant":{"id":5,"url":"http://localhost:8037/api/tenancy/tenants/5/","display":"Dunder-Mifflin,
+        Inc.","name":"Dunder-Mifflin, Inc.","slug":"dunder-mifflin"},"facility":"","time_zone":null,"description":"","physical_address":"","shipping_address":"","latitude":null,"longitude":null,"comments":"","asns":[],"tags":[{"id":3,"url":"http://localhost:8037/api/extras/tags/3/","display":"Charlie","name":"Charlie","slug":"charlie","color":"e91e63"},{"id":14,"url":"http://localhost:8037/api/extras/tags/14/","display":"November","name":"November","slug":"november","color":"2f6a31"},{"id":16,"url":"http://localhost:8037/api/extras/tags/16/","display":"Papa","name":"Papa","slug":"papa","color":"8bc34a"}],"custom_fields":{},"created":"2020-12-19T00:00:00Z","last_updated":"2021-12-30T15:45:37.397000Z","circuit_count":2,"device_count":4,"prefix_count":5,"rack_count":1,"virtualmachine_count":0,"vlan_count":3},{"id":4,"url":"http://localhost:8037/api/dcim/sites/4/","display":"DM-Binghamton","name":"DM-Binghamton","slug":"dm-binghamton","status":{"value":"active","label":"Active"},"region":{"id":43,"url":"http://localhost:8037/api/dcim/regions/43/","display":"New
+        York","name":"New York","slug":"us-ny","_depth":2},"group":{"id":2,"url":"http://localhost:8037/api/dcim/site-groups/2/","display":"Branch
+        Offices","name":"Branch Offices","slug":"branch-offices","_depth":1},"tenant":{"id":5,"url":"http://localhost:8037/api/tenancy/tenants/5/","display":"Dunder-Mifflin,
+        Inc.","name":"Dunder-Mifflin, Inc.","slug":"dunder-mifflin"},"facility":"","time_zone":null,"description":"","physical_address":"","shipping_address":"","latitude":null,"longitude":null,"comments":"","asns":[],"tags":[{"id":7,"url":"http://localhost:8037/api/extras/tags/7/","display":"Golf","name":"Golf","slug":"golf","color":"673ab7"},{"id":17,"url":"http://localhost:8037/api/extras/tags/17/","display":"Quebec","name":"Quebec","slug":"quebec","color":"cddc39"},{"id":18,"url":"http://localhost:8037/api/extras/tags/18/","display":"Romeo","name":"Romeo","slug":"romeo","color":"ffeb3b"}],"custom_fields":{},"created":"2020-12-19T00:00:00Z","last_updated":"2021-12-30T15:45:37.409000Z","circuit_count":2,"device_count":4,"prefix_count":5,"rack_count":1,"virtualmachine_count":0,"vlan_count":3}]}'
+    headers:
+      Allow:
+      - GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS
+      Content-Length:
+      - '6688'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - Unit/1.31.1
+      Vary:
+      - HX-Request, Cookie, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.33.1
+    method: GET
+    uri: http://localhost:8037/api/dcim/sites/24/
+  response:
+    body:
+      string: '{"id":24,"url":"http://localhost:8037/api/dcim/sites/24/","display":"Butler
+        Communications","name":"Butler Communications","slug":"ncsu-128","status":{"value":"active","label":"Active"},"region":{"id":40,"url":"http://localhost:8037/api/dcim/regions/40/","display":"North
+        Carolina","name":"North Carolina","slug":"us-nc","_depth":2},"group":null,"tenant":{"id":13,"url":"http://localhost:8037/api/tenancy/tenants/13/","display":"NC
+        State University","name":"NC State University","slug":"nc-state"},"facility":"BUT","time_zone":null,"description":"","physical_address":"3210
+        Faucette Dr., Raleigh, NC 27607","shipping_address":"","latitude":null,"longitude":null,"comments":"","asns":[],"tags":[{"id":7,"url":"http://localhost:8037/api/extras/tags/7/","display":"Golf","name":"Golf","slug":"golf","color":"673ab7"},{"id":12,"url":"http://localhost:8037/api/extras/tags/12/","display":"Lima","name":"Lima","slug":"lima","color":"009688"},{"id":24,"url":"http://localhost:8037/api/extras/tags/24/","display":"X-ray","name":"X-ray","slug":"x-ray","color":"9e9e9e"}],"custom_fields":{},"created":"2021-04-02T00:00:00Z","last_updated":"2021-12-30T15:45:37.371000Z","circuit_count":1,"device_count":2,"prefix_count":0,"rack_count":1,"virtualmachine_count":0,"vlan_count":0}'
+    headers:
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      Content-Length:
+      - '1266'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - Unit/1.31.1
+      Vary:
+      - HX-Request, Cookie, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/integration/fixtures/v37/dcim_site_01/expected.yaml
+++ b/tests/integration/fixtures/v37/dcim_site_01/expected.yaml
@@ -1,0 +1,30 @@
+# AUTO-GENERATED - DO NOT EDIT
+# This file is generated from definitions.yaml
+# To regenerate: python -m tests.integration.generate_fixtures
+
+definition:
+  id: dcim_site_01
+  method: dcim_site
+  args:
+    site_id:
+      call: dcim_sites
+      args:
+        limit: 5
+      extract: results[0].id
+call:
+  client_call: dcim_site
+  client_call_args: []
+  client_call_kwargs:
+    site_id: 24
+output: !!python/object:annetbox.v37.models.Site
+  id: 24
+  name: Butler Communications
+  display: Butler Communications
+  url: http://localhost:8037/api/dcim/sites/24/
+  slug: ncsu-128
+  status: !!python/object:annetbox.v37.models.Label
+    value: active
+    label: Active
+  custom_fields: {}
+  created: 2021-04-02 00:00:00+00:00
+  last_updated: 2021-12-30 15:45:37.371000+00:00

--- a/tests/integration/fixtures/v37/dcim_sites_01/cassette.yaml
+++ b/tests/integration/fixtures/v37/dcim_sites_01/cassette.yaml
@@ -1,0 +1,56 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.33.1
+    method: GET
+    uri: http://localhost:8037/api/dcim/sites/?limit=5&offset=0
+  response:
+    body:
+      string: '{"count":24,"next":"http://localhost:8037/api/dcim/sites/?limit=5&offset=5","previous":null,"results":[{"id":24,"url":"http://localhost:8037/api/dcim/sites/24/","display":"Butler
+        Communications","name":"Butler Communications","slug":"ncsu-128","status":{"value":"active","label":"Active"},"region":{"id":40,"url":"http://localhost:8037/api/dcim/regions/40/","display":"North
+        Carolina","name":"North Carolina","slug":"us-nc","_depth":2},"group":null,"tenant":{"id":13,"url":"http://localhost:8037/api/tenancy/tenants/13/","display":"NC
+        State University","name":"NC State University","slug":"nc-state"},"facility":"BUT","time_zone":null,"description":"","physical_address":"3210
+        Faucette Dr., Raleigh, NC 27607","shipping_address":"","latitude":null,"longitude":null,"comments":"","asns":[],"tags":[{"id":7,"url":"http://localhost:8037/api/extras/tags/7/","display":"Golf","name":"Golf","slug":"golf","color":"673ab7"},{"id":12,"url":"http://localhost:8037/api/extras/tags/12/","display":"Lima","name":"Lima","slug":"lima","color":"009688"},{"id":24,"url":"http://localhost:8037/api/extras/tags/24/","display":"X-ray","name":"X-ray","slug":"x-ray","color":"9e9e9e"}],"custom_fields":{},"created":"2021-04-02T00:00:00Z","last_updated":"2021-12-30T15:45:37.371000Z","circuit_count":1,"device_count":2,"prefix_count":0,"rack_count":1,"virtualmachine_count":0,"vlan_count":0},{"id":22,"url":"http://localhost:8037/api/dcim/sites/22/","display":"D.
+        S. Weaver Labs","name":"D. S. Weaver Labs","slug":"ncsu-117","status":{"value":"active","label":"Active"},"region":{"id":40,"url":"http://localhost:8037/api/dcim/regions/40/","display":"North
+        Carolina","name":"North Carolina","slug":"us-nc","_depth":2},"group":null,"tenant":{"id":13,"url":"http://localhost:8037/api/tenancy/tenants/13/","display":"NC
+        State University","name":"NC State University","slug":"nc-state"},"facility":"DSW","time_zone":null,"description":"","physical_address":"3110
+        Faucette Dr., Raleigh, NC 27607","shipping_address":"","latitude":null,"longitude":null,"comments":"","asns":[],"tags":[{"id":17,"url":"http://localhost:8037/api/extras/tags/17/","display":"Quebec","name":"Quebec","slug":"quebec","color":"cddc39"},{"id":20,"url":"http://localhost:8037/api/extras/tags/20/","display":"Tango","name":"Tango","slug":"tango","color":"ff9800"},{"id":24,"url":"http://localhost:8037/api/extras/tags/24/","display":"X-ray","name":"X-ray","slug":"x-ray","color":"9e9e9e"}],"custom_fields":{},"created":"2021-04-02T00:00:00Z","last_updated":"2021-12-30T15:45:37.549000Z","circuit_count":1,"device_count":2,"prefix_count":0,"rack_count":1,"virtualmachine_count":0,"vlan_count":0},{"id":2,"url":"http://localhost:8037/api/dcim/sites/2/","display":"DM-Akron","name":"DM-Akron","slug":"dm-akron","status":{"value":"active","label":"Active"},"region":{"id":51,"url":"http://localhost:8037/api/dcim/regions/51/","display":"Ohio","name":"Ohio","slug":"us-oh","_depth":2},"group":{"id":2,"url":"http://localhost:8037/api/dcim/site-groups/2/","display":"Branch
+        Offices","name":"Branch Offices","slug":"branch-offices","_depth":1},"tenant":{"id":5,"url":"http://localhost:8037/api/tenancy/tenants/5/","display":"Dunder-Mifflin,
+        Inc.","name":"Dunder-Mifflin, Inc.","slug":"dunder-mifflin"},"facility":"","time_zone":null,"description":"","physical_address":"","shipping_address":"","latitude":null,"longitude":null,"comments":"","asns":[],"tags":[{"id":1,"url":"http://localhost:8037/api/extras/tags/1/","display":"Alpha","name":"Alpha","slug":"alpha","color":"aa1409"},{"id":2,"url":"http://localhost:8037/api/extras/tags/2/","display":"Bravo","name":"Bravo","slug":"bravo","color":"f44336"},{"id":7,"url":"http://localhost:8037/api/extras/tags/7/","display":"Golf","name":"Golf","slug":"golf","color":"673ab7"}],"custom_fields":{},"created":"2020-12-19T00:00:00Z","last_updated":"2021-12-30T15:45:37.384000Z","circuit_count":2,"device_count":4,"prefix_count":5,"rack_count":1,"virtualmachine_count":0,"vlan_count":3},{"id":3,"url":"http://localhost:8037/api/dcim/sites/3/","display":"DM-Albany","name":"DM-Albany","slug":"dm-albany","status":{"value":"active","label":"Active"},"region":{"id":43,"url":"http://localhost:8037/api/dcim/regions/43/","display":"New
+        York","name":"New York","slug":"us-ny","_depth":2},"group":{"id":2,"url":"http://localhost:8037/api/dcim/site-groups/2/","display":"Branch
+        Offices","name":"Branch Offices","slug":"branch-offices","_depth":1},"tenant":{"id":5,"url":"http://localhost:8037/api/tenancy/tenants/5/","display":"Dunder-Mifflin,
+        Inc.","name":"Dunder-Mifflin, Inc.","slug":"dunder-mifflin"},"facility":"","time_zone":null,"description":"","physical_address":"","shipping_address":"","latitude":null,"longitude":null,"comments":"","asns":[],"tags":[{"id":3,"url":"http://localhost:8037/api/extras/tags/3/","display":"Charlie","name":"Charlie","slug":"charlie","color":"e91e63"},{"id":14,"url":"http://localhost:8037/api/extras/tags/14/","display":"November","name":"November","slug":"november","color":"2f6a31"},{"id":16,"url":"http://localhost:8037/api/extras/tags/16/","display":"Papa","name":"Papa","slug":"papa","color":"8bc34a"}],"custom_fields":{},"created":"2020-12-19T00:00:00Z","last_updated":"2021-12-30T15:45:37.397000Z","circuit_count":2,"device_count":4,"prefix_count":5,"rack_count":1,"virtualmachine_count":0,"vlan_count":3},{"id":4,"url":"http://localhost:8037/api/dcim/sites/4/","display":"DM-Binghamton","name":"DM-Binghamton","slug":"dm-binghamton","status":{"value":"active","label":"Active"},"region":{"id":43,"url":"http://localhost:8037/api/dcim/regions/43/","display":"New
+        York","name":"New York","slug":"us-ny","_depth":2},"group":{"id":2,"url":"http://localhost:8037/api/dcim/site-groups/2/","display":"Branch
+        Offices","name":"Branch Offices","slug":"branch-offices","_depth":1},"tenant":{"id":5,"url":"http://localhost:8037/api/tenancy/tenants/5/","display":"Dunder-Mifflin,
+        Inc.","name":"Dunder-Mifflin, Inc.","slug":"dunder-mifflin"},"facility":"","time_zone":null,"description":"","physical_address":"","shipping_address":"","latitude":null,"longitude":null,"comments":"","asns":[],"tags":[{"id":7,"url":"http://localhost:8037/api/extras/tags/7/","display":"Golf","name":"Golf","slug":"golf","color":"673ab7"},{"id":17,"url":"http://localhost:8037/api/extras/tags/17/","display":"Quebec","name":"Quebec","slug":"quebec","color":"cddc39"},{"id":18,"url":"http://localhost:8037/api/extras/tags/18/","display":"Romeo","name":"Romeo","slug":"romeo","color":"ffeb3b"}],"custom_fields":{},"created":"2020-12-19T00:00:00Z","last_updated":"2021-12-30T15:45:37.409000Z","circuit_count":2,"device_count":4,"prefix_count":5,"rack_count":1,"virtualmachine_count":0,"vlan_count":3}]}'
+    headers:
+      Allow:
+      - GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS
+      Content-Length:
+      - '6688'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - Unit/1.31.1
+      Vary:
+      - HX-Request, Cookie, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/integration/fixtures/v37/dcim_sites_01/expected.yaml
+++ b/tests/integration/fixtures/v37/dcim_sites_01/expected.yaml
@@ -1,0 +1,79 @@
+# AUTO-GENERATED - DO NOT EDIT
+# This file is generated from definitions.yaml
+# To regenerate: python -m tests.integration.generate_fixtures
+
+definition:
+  id: dcim_sites_01
+  method: dcim_sites
+  args:
+    limit: 5
+call:
+  client_call: dcim_sites
+  client_call_args: []
+  client_call_kwargs:
+    limit: 5
+output: !!python/object:annetbox.base.models.PagingResponse
+  next: http://localhost:8037/api/dcim/sites/?limit=5&offset=5
+  previous: null
+  count: 24
+  results:
+  - !!python/object:annetbox.v37.models.Site
+    id: 24
+    name: Butler Communications
+    display: Butler Communications
+    url: http://localhost:8037/api/dcim/sites/24/
+    slug: ncsu-128
+    status: !!python/object:annetbox.v37.models.Label
+      value: active
+      label: Active
+    custom_fields: {}
+    created: 2021-04-02 00:00:00+00:00
+    last_updated: 2021-12-30 15:45:37.371000+00:00
+  - !!python/object:annetbox.v37.models.Site
+    id: 22
+    name: D. S. Weaver Labs
+    display: D. S. Weaver Labs
+    url: http://localhost:8037/api/dcim/sites/22/
+    slug: ncsu-117
+    status: !!python/object:annetbox.v37.models.Label
+      value: active
+      label: Active
+    custom_fields: {}
+    created: 2021-04-02 00:00:00+00:00
+    last_updated: 2021-12-30 15:45:37.549000+00:00
+  - !!python/object:annetbox.v37.models.Site
+    id: 2
+    name: DM-Akron
+    display: DM-Akron
+    url: http://localhost:8037/api/dcim/sites/2/
+    slug: dm-akron
+    status: !!python/object:annetbox.v37.models.Label
+      value: active
+      label: Active
+    custom_fields: {}
+    created: 2020-12-19 00:00:00+00:00
+    last_updated: 2021-12-30 15:45:37.384000+00:00
+  - !!python/object:annetbox.v37.models.Site
+    id: 3
+    name: DM-Albany
+    display: DM-Albany
+    url: http://localhost:8037/api/dcim/sites/3/
+    slug: dm-albany
+    status: !!python/object:annetbox.v37.models.Label
+      value: active
+      label: Active
+    custom_fields: {}
+    created: 2020-12-19 00:00:00+00:00
+    last_updated: 2021-12-30 15:45:37.397000+00:00
+  - !!python/object:annetbox.v37.models.Site
+    id: 4
+    name: DM-Binghamton
+    display: DM-Binghamton
+    url: http://localhost:8037/api/dcim/sites/4/
+    slug: dm-binghamton
+    status: !!python/object:annetbox.v37.models.Label
+      value: active
+      label: Active
+    custom_fields: {}
+    created: 2020-12-19 00:00:00+00:00
+    last_updated: 2021-12-30 15:45:37.409000+00:00

--- a/tests/integration/fixtures/v37/lock.yaml
+++ b/tests/integration/fixtures/v37/lock.yaml
@@ -99,6 +99,18 @@ test_cases:
     sha256: eebd39bd76fbce5d25e87a4a69f52c6b3a07f584e51c42454e72f52de8f27a8d
   - path: expected.yaml
     sha256: 1c68c74fcb5480a1805b8527a5fe2cf1b8b2cfa810fc6f5aa9d26f0b7460b906
+- test_case: dcim_site_01
+  files:
+  - path: cassette.yaml
+    sha256: 35aab7bd043deaadc1891f52778ad348fab10dd7a499457ed4b275153152b580
+  - path: expected.yaml
+    sha256: 7ace4d81d97b6001200963b122cb1f6550e589d7a1b2667e2abf8660d2e70698
+- test_case: dcim_sites_01
+  files:
+  - path: cassette.yaml
+    sha256: c45307dd9c2b9968abae728938dd9e38355396c9813509d0490bfe2826ace11d
+  - path: expected.yaml
+    sha256: b84d1e363c7899b3abe1542c0a06964d93f1b41778cfe9c0f3eecf1119b574d7
 - test_case: ipam_all_ip_addresses_01
   files:
   - path: cassette.yaml
@@ -117,4 +129,4 @@ test_cases:
     sha256: a81a435b6fc8ce64b9dd692fea291c4f69c21c45144bb833c51053c859d08edd
   - path: expected.yaml
     sha256: 86dfbd7cc8a28fddd678ba3936451aa44ad049db1daf29e28edcb4638d62c9ac
-sha256: c581bbbb8950fe87f677ab94489ab1214dba503f4589fe0846e919b59207d798
+sha256: 41b9f18c0217f5daa4270400a5b742b2aa88e9f217ddc53ed31214292fe73e06

--- a/tests/integration/fixtures/v41/dcim_site_01/cassette.yaml
+++ b/tests/integration/fixtures/v41/dcim_site_01/cassette.yaml
@@ -1,0 +1,102 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.33.1
+    method: GET
+    uri: http://localhost:8041/api/dcim/sites/?limit=5&offset=0
+  response:
+    body:
+      string: '{"count":24,"next":"http://localhost:8041/api/dcim/sites/?limit=5&offset=5","previous":null,"results":[{"id":24,"url":"http://localhost:8041/api/dcim/sites/24/","display_url":"http://localhost:8041/dcim/sites/24/","display":"Butler
+        Communications","name":"Butler Communications","slug":"ncsu-128","status":{"value":"active","label":"Active"},"region":{"id":40,"url":"http://localhost:8041/api/dcim/regions/40/","display":"North
+        Carolina","name":"North Carolina","slug":"us-nc","description":"","site_count":0,"_depth":2},"group":null,"tenant":{"id":13,"url":"http://localhost:8041/api/tenancy/tenants/13/","display":"NC
+        State University","name":"NC State University","slug":"nc-state","description":""},"facility":"BUT","time_zone":null,"description":"","physical_address":"3210
+        Faucette Dr., Raleigh, NC 27607","shipping_address":"","latitude":null,"longitude":null,"comments":"","asns":[],"tags":[{"id":7,"url":"http://localhost:8041/api/extras/tags/7/","display_url":"http://localhost:8041/extras/tags/7/","display":"Golf","name":"Golf","slug":"golf","color":"673ab7"},{"id":12,"url":"http://localhost:8041/api/extras/tags/12/","display_url":"http://localhost:8041/extras/tags/12/","display":"Lima","name":"Lima","slug":"lima","color":"009688"},{"id":24,"url":"http://localhost:8041/api/extras/tags/24/","display_url":"http://localhost:8041/extras/tags/24/","display":"X-ray","name":"X-ray","slug":"x-ray","color":"9e9e9e"}],"custom_fields":{},"created":"2021-04-02T00:00:00Z","last_updated":"2021-12-30T15:45:37.371000Z","circuit_count":1,"device_count":2,"prefix_count":0,"rack_count":1,"virtualmachine_count":0,"vlan_count":0},{"id":22,"url":"http://localhost:8041/api/dcim/sites/22/","display_url":"http://localhost:8041/dcim/sites/22/","display":"D.
+        S. Weaver Labs","name":"D. S. Weaver Labs","slug":"ncsu-117","status":{"value":"active","label":"Active"},"region":{"id":40,"url":"http://localhost:8041/api/dcim/regions/40/","display":"North
+        Carolina","name":"North Carolina","slug":"us-nc","description":"","site_count":0,"_depth":2},"group":null,"tenant":{"id":13,"url":"http://localhost:8041/api/tenancy/tenants/13/","display":"NC
+        State University","name":"NC State University","slug":"nc-state","description":""},"facility":"DSW","time_zone":null,"description":"","physical_address":"3110
+        Faucette Dr., Raleigh, NC 27607","shipping_address":"","latitude":null,"longitude":null,"comments":"","asns":[],"tags":[{"id":17,"url":"http://localhost:8041/api/extras/tags/17/","display_url":"http://localhost:8041/extras/tags/17/","display":"Quebec","name":"Quebec","slug":"quebec","color":"cddc39"},{"id":20,"url":"http://localhost:8041/api/extras/tags/20/","display_url":"http://localhost:8041/extras/tags/20/","display":"Tango","name":"Tango","slug":"tango","color":"ff9800"},{"id":24,"url":"http://localhost:8041/api/extras/tags/24/","display_url":"http://localhost:8041/extras/tags/24/","display":"X-ray","name":"X-ray","slug":"x-ray","color":"9e9e9e"}],"custom_fields":{},"created":"2021-04-02T00:00:00Z","last_updated":"2021-12-30T15:45:37.549000Z","circuit_count":1,"device_count":2,"prefix_count":0,"rack_count":1,"virtualmachine_count":0,"vlan_count":0},{"id":2,"url":"http://localhost:8041/api/dcim/sites/2/","display_url":"http://localhost:8041/dcim/sites/2/","display":"DM-Akron","name":"DM-Akron","slug":"dm-akron","status":{"value":"active","label":"Active"},"region":{"id":51,"url":"http://localhost:8041/api/dcim/regions/51/","display":"Ohio","name":"Ohio","slug":"us-oh","description":"","site_count":0,"_depth":2},"group":{"id":2,"url":"http://localhost:8041/api/dcim/site-groups/2/","display":"Branch
+        Offices","name":"Branch Offices","slug":"branch-offices","description":"","site_count":0,"_depth":1},"tenant":{"id":5,"url":"http://localhost:8041/api/tenancy/tenants/5/","display":"Dunder-Mifflin,
+        Inc.","name":"Dunder-Mifflin, Inc.","slug":"dunder-mifflin","description":""},"facility":"","time_zone":null,"description":"","physical_address":"","shipping_address":"","latitude":null,"longitude":null,"comments":"","asns":[],"tags":[{"id":1,"url":"http://localhost:8041/api/extras/tags/1/","display_url":"http://localhost:8041/extras/tags/1/","display":"Alpha","name":"Alpha","slug":"alpha","color":"aa1409"},{"id":2,"url":"http://localhost:8041/api/extras/tags/2/","display_url":"http://localhost:8041/extras/tags/2/","display":"Bravo","name":"Bravo","slug":"bravo","color":"f44336"},{"id":7,"url":"http://localhost:8041/api/extras/tags/7/","display_url":"http://localhost:8041/extras/tags/7/","display":"Golf","name":"Golf","slug":"golf","color":"673ab7"}],"custom_fields":{},"created":"2020-12-19T00:00:00Z","last_updated":"2021-12-30T15:45:37.384000Z","circuit_count":2,"device_count":4,"prefix_count":5,"rack_count":1,"virtualmachine_count":0,"vlan_count":3},{"id":3,"url":"http://localhost:8041/api/dcim/sites/3/","display_url":"http://localhost:8041/dcim/sites/3/","display":"DM-Albany","name":"DM-Albany","slug":"dm-albany","status":{"value":"active","label":"Active"},"region":{"id":43,"url":"http://localhost:8041/api/dcim/regions/43/","display":"New
+        York","name":"New York","slug":"us-ny","description":"","site_count":0,"_depth":2},"group":{"id":2,"url":"http://localhost:8041/api/dcim/site-groups/2/","display":"Branch
+        Offices","name":"Branch Offices","slug":"branch-offices","description":"","site_count":0,"_depth":1},"tenant":{"id":5,"url":"http://localhost:8041/api/tenancy/tenants/5/","display":"Dunder-Mifflin,
+        Inc.","name":"Dunder-Mifflin, Inc.","slug":"dunder-mifflin","description":""},"facility":"","time_zone":null,"description":"","physical_address":"","shipping_address":"","latitude":null,"longitude":null,"comments":"","asns":[],"tags":[{"id":3,"url":"http://localhost:8041/api/extras/tags/3/","display_url":"http://localhost:8041/extras/tags/3/","display":"Charlie","name":"Charlie","slug":"charlie","color":"e91e63"},{"id":14,"url":"http://localhost:8041/api/extras/tags/14/","display_url":"http://localhost:8041/extras/tags/14/","display":"November","name":"November","slug":"november","color":"2f6a31"},{"id":16,"url":"http://localhost:8041/api/extras/tags/16/","display_url":"http://localhost:8041/extras/tags/16/","display":"Papa","name":"Papa","slug":"papa","color":"8bc34a"}],"custom_fields":{},"created":"2020-12-19T00:00:00Z","last_updated":"2021-12-30T15:45:37.397000Z","circuit_count":2,"device_count":4,"prefix_count":5,"rack_count":1,"virtualmachine_count":0,"vlan_count":3},{"id":4,"url":"http://localhost:8041/api/dcim/sites/4/","display_url":"http://localhost:8041/dcim/sites/4/","display":"DM-Binghamton","name":"DM-Binghamton","slug":"dm-binghamton","status":{"value":"active","label":"Active"},"region":{"id":43,"url":"http://localhost:8041/api/dcim/regions/43/","display":"New
+        York","name":"New York","slug":"us-ny","description":"","site_count":0,"_depth":2},"group":{"id":2,"url":"http://localhost:8041/api/dcim/site-groups/2/","display":"Branch
+        Offices","name":"Branch Offices","slug":"branch-offices","description":"","site_count":0,"_depth":1},"tenant":{"id":5,"url":"http://localhost:8041/api/tenancy/tenants/5/","display":"Dunder-Mifflin,
+        Inc.","name":"Dunder-Mifflin, Inc.","slug":"dunder-mifflin","description":""},"facility":"","time_zone":null,"description":"","physical_address":"","shipping_address":"","latitude":null,"longitude":null,"comments":"","asns":[],"tags":[{"id":7,"url":"http://localhost:8041/api/extras/tags/7/","display_url":"http://localhost:8041/extras/tags/7/","display":"Golf","name":"Golf","slug":"golf","color":"673ab7"},{"id":17,"url":"http://localhost:8041/api/extras/tags/17/","display_url":"http://localhost:8041/extras/tags/17/","display":"Quebec","name":"Quebec","slug":"quebec","color":"cddc39"},{"id":18,"url":"http://localhost:8041/api/extras/tags/18/","display_url":"http://localhost:8041/extras/tags/18/","display":"Romeo","name":"Romeo","slug":"romeo","color":"ffeb3b"}],"custom_fields":{},"created":"2020-12-19T00:00:00Z","last_updated":"2021-12-30T15:45:37.409000Z","circuit_count":2,"device_count":4,"prefix_count":5,"rack_count":1,"virtualmachine_count":0,"vlan_count":3}]}'
+    headers:
+      Allow:
+      - GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS
+      Content-Language:
+      - en
+      Content-Length:
+      - '8095'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - Unit/1.33.0
+      Vary:
+      - HX-Request, Accept-Language, Cookie, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.33.1
+    method: GET
+    uri: http://localhost:8041/api/dcim/sites/24/
+  response:
+    body:
+      string: '{"id":24,"url":"http://localhost:8041/api/dcim/sites/24/","display_url":"http://localhost:8041/dcim/sites/24/","display":"Butler
+        Communications","name":"Butler Communications","slug":"ncsu-128","status":{"value":"active","label":"Active"},"region":{"id":40,"url":"http://localhost:8041/api/dcim/regions/40/","display":"North
+        Carolina","name":"North Carolina","slug":"us-nc","description":"","site_count":0,"_depth":2},"group":null,"tenant":{"id":13,"url":"http://localhost:8041/api/tenancy/tenants/13/","display":"NC
+        State University","name":"NC State University","slug":"nc-state","description":""},"facility":"BUT","time_zone":null,"description":"","physical_address":"3210
+        Faucette Dr., Raleigh, NC 27607","shipping_address":"","latitude":null,"longitude":null,"comments":"","asns":[],"tags":[{"id":7,"url":"http://localhost:8041/api/extras/tags/7/","display_url":"http://localhost:8041/extras/tags/7/","display":"Golf","name":"Golf","slug":"golf","color":"673ab7"},{"id":12,"url":"http://localhost:8041/api/extras/tags/12/","display_url":"http://localhost:8041/extras/tags/12/","display":"Lima","name":"Lima","slug":"lima","color":"009688"},{"id":24,"url":"http://localhost:8041/api/extras/tags/24/","display_url":"http://localhost:8041/extras/tags/24/","display":"X-ray","name":"X-ray","slug":"x-ray","color":"9e9e9e"}],"custom_fields":{},"created":"2021-04-02T00:00:00Z","last_updated":"2021-12-30T15:45:37.371000Z","circuit_count":1,"device_count":2,"prefix_count":0,"rack_count":1,"virtualmachine_count":0,"vlan_count":0}'
+    headers:
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      Content-Language:
+      - en
+      Content-Length:
+      - '1529'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - Unit/1.33.0
+      Vary:
+      - HX-Request, Accept-Language, Cookie, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/integration/fixtures/v41/dcim_site_01/expected.yaml
+++ b/tests/integration/fixtures/v41/dcim_site_01/expected.yaml
@@ -1,0 +1,30 @@
+# AUTO-GENERATED - DO NOT EDIT
+# This file is generated from definitions.yaml
+# To regenerate: python -m tests.integration.generate_fixtures
+
+definition:
+  id: dcim_site_01
+  method: dcim_site
+  args:
+    site_id:
+      call: dcim_sites
+      args:
+        limit: 5
+      extract: results[0].id
+call:
+  client_call: dcim_site
+  client_call_args: []
+  client_call_kwargs:
+    site_id: 24
+output: !!python/object:annetbox.v41.models.Site
+  id: 24
+  name: Butler Communications
+  display: Butler Communications
+  url: http://localhost:8041/api/dcim/sites/24/
+  slug: ncsu-128
+  status: !!python/object:annetbox.v41.models.Label
+    value: active
+    label: Active
+  custom_fields: {}
+  created: 2021-04-02 00:00:00+00:00
+  last_updated: 2021-12-30 15:45:37.371000+00:00

--- a/tests/integration/fixtures/v41/dcim_sites_01/cassette.yaml
+++ b/tests/integration/fixtures/v41/dcim_sites_01/cassette.yaml
@@ -1,0 +1,58 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.33.1
+    method: GET
+    uri: http://localhost:8041/api/dcim/sites/?limit=5&offset=0
+  response:
+    body:
+      string: '{"count":24,"next":"http://localhost:8041/api/dcim/sites/?limit=5&offset=5","previous":null,"results":[{"id":24,"url":"http://localhost:8041/api/dcim/sites/24/","display_url":"http://localhost:8041/dcim/sites/24/","display":"Butler
+        Communications","name":"Butler Communications","slug":"ncsu-128","status":{"value":"active","label":"Active"},"region":{"id":40,"url":"http://localhost:8041/api/dcim/regions/40/","display":"North
+        Carolina","name":"North Carolina","slug":"us-nc","description":"","site_count":0,"_depth":2},"group":null,"tenant":{"id":13,"url":"http://localhost:8041/api/tenancy/tenants/13/","display":"NC
+        State University","name":"NC State University","slug":"nc-state","description":""},"facility":"BUT","time_zone":null,"description":"","physical_address":"3210
+        Faucette Dr., Raleigh, NC 27607","shipping_address":"","latitude":null,"longitude":null,"comments":"","asns":[],"tags":[{"id":7,"url":"http://localhost:8041/api/extras/tags/7/","display_url":"http://localhost:8041/extras/tags/7/","display":"Golf","name":"Golf","slug":"golf","color":"673ab7"},{"id":12,"url":"http://localhost:8041/api/extras/tags/12/","display_url":"http://localhost:8041/extras/tags/12/","display":"Lima","name":"Lima","slug":"lima","color":"009688"},{"id":24,"url":"http://localhost:8041/api/extras/tags/24/","display_url":"http://localhost:8041/extras/tags/24/","display":"X-ray","name":"X-ray","slug":"x-ray","color":"9e9e9e"}],"custom_fields":{},"created":"2021-04-02T00:00:00Z","last_updated":"2021-12-30T15:45:37.371000Z","circuit_count":1,"device_count":2,"prefix_count":0,"rack_count":1,"virtualmachine_count":0,"vlan_count":0},{"id":22,"url":"http://localhost:8041/api/dcim/sites/22/","display_url":"http://localhost:8041/dcim/sites/22/","display":"D.
+        S. Weaver Labs","name":"D. S. Weaver Labs","slug":"ncsu-117","status":{"value":"active","label":"Active"},"region":{"id":40,"url":"http://localhost:8041/api/dcim/regions/40/","display":"North
+        Carolina","name":"North Carolina","slug":"us-nc","description":"","site_count":0,"_depth":2},"group":null,"tenant":{"id":13,"url":"http://localhost:8041/api/tenancy/tenants/13/","display":"NC
+        State University","name":"NC State University","slug":"nc-state","description":""},"facility":"DSW","time_zone":null,"description":"","physical_address":"3110
+        Faucette Dr., Raleigh, NC 27607","shipping_address":"","latitude":null,"longitude":null,"comments":"","asns":[],"tags":[{"id":17,"url":"http://localhost:8041/api/extras/tags/17/","display_url":"http://localhost:8041/extras/tags/17/","display":"Quebec","name":"Quebec","slug":"quebec","color":"cddc39"},{"id":20,"url":"http://localhost:8041/api/extras/tags/20/","display_url":"http://localhost:8041/extras/tags/20/","display":"Tango","name":"Tango","slug":"tango","color":"ff9800"},{"id":24,"url":"http://localhost:8041/api/extras/tags/24/","display_url":"http://localhost:8041/extras/tags/24/","display":"X-ray","name":"X-ray","slug":"x-ray","color":"9e9e9e"}],"custom_fields":{},"created":"2021-04-02T00:00:00Z","last_updated":"2021-12-30T15:45:37.549000Z","circuit_count":1,"device_count":2,"prefix_count":0,"rack_count":1,"virtualmachine_count":0,"vlan_count":0},{"id":2,"url":"http://localhost:8041/api/dcim/sites/2/","display_url":"http://localhost:8041/dcim/sites/2/","display":"DM-Akron","name":"DM-Akron","slug":"dm-akron","status":{"value":"active","label":"Active"},"region":{"id":51,"url":"http://localhost:8041/api/dcim/regions/51/","display":"Ohio","name":"Ohio","slug":"us-oh","description":"","site_count":0,"_depth":2},"group":{"id":2,"url":"http://localhost:8041/api/dcim/site-groups/2/","display":"Branch
+        Offices","name":"Branch Offices","slug":"branch-offices","description":"","site_count":0,"_depth":1},"tenant":{"id":5,"url":"http://localhost:8041/api/tenancy/tenants/5/","display":"Dunder-Mifflin,
+        Inc.","name":"Dunder-Mifflin, Inc.","slug":"dunder-mifflin","description":""},"facility":"","time_zone":null,"description":"","physical_address":"","shipping_address":"","latitude":null,"longitude":null,"comments":"","asns":[],"tags":[{"id":1,"url":"http://localhost:8041/api/extras/tags/1/","display_url":"http://localhost:8041/extras/tags/1/","display":"Alpha","name":"Alpha","slug":"alpha","color":"aa1409"},{"id":2,"url":"http://localhost:8041/api/extras/tags/2/","display_url":"http://localhost:8041/extras/tags/2/","display":"Bravo","name":"Bravo","slug":"bravo","color":"f44336"},{"id":7,"url":"http://localhost:8041/api/extras/tags/7/","display_url":"http://localhost:8041/extras/tags/7/","display":"Golf","name":"Golf","slug":"golf","color":"673ab7"}],"custom_fields":{},"created":"2020-12-19T00:00:00Z","last_updated":"2021-12-30T15:45:37.384000Z","circuit_count":2,"device_count":4,"prefix_count":5,"rack_count":1,"virtualmachine_count":0,"vlan_count":3},{"id":3,"url":"http://localhost:8041/api/dcim/sites/3/","display_url":"http://localhost:8041/dcim/sites/3/","display":"DM-Albany","name":"DM-Albany","slug":"dm-albany","status":{"value":"active","label":"Active"},"region":{"id":43,"url":"http://localhost:8041/api/dcim/regions/43/","display":"New
+        York","name":"New York","slug":"us-ny","description":"","site_count":0,"_depth":2},"group":{"id":2,"url":"http://localhost:8041/api/dcim/site-groups/2/","display":"Branch
+        Offices","name":"Branch Offices","slug":"branch-offices","description":"","site_count":0,"_depth":1},"tenant":{"id":5,"url":"http://localhost:8041/api/tenancy/tenants/5/","display":"Dunder-Mifflin,
+        Inc.","name":"Dunder-Mifflin, Inc.","slug":"dunder-mifflin","description":""},"facility":"","time_zone":null,"description":"","physical_address":"","shipping_address":"","latitude":null,"longitude":null,"comments":"","asns":[],"tags":[{"id":3,"url":"http://localhost:8041/api/extras/tags/3/","display_url":"http://localhost:8041/extras/tags/3/","display":"Charlie","name":"Charlie","slug":"charlie","color":"e91e63"},{"id":14,"url":"http://localhost:8041/api/extras/tags/14/","display_url":"http://localhost:8041/extras/tags/14/","display":"November","name":"November","slug":"november","color":"2f6a31"},{"id":16,"url":"http://localhost:8041/api/extras/tags/16/","display_url":"http://localhost:8041/extras/tags/16/","display":"Papa","name":"Papa","slug":"papa","color":"8bc34a"}],"custom_fields":{},"created":"2020-12-19T00:00:00Z","last_updated":"2021-12-30T15:45:37.397000Z","circuit_count":2,"device_count":4,"prefix_count":5,"rack_count":1,"virtualmachine_count":0,"vlan_count":3},{"id":4,"url":"http://localhost:8041/api/dcim/sites/4/","display_url":"http://localhost:8041/dcim/sites/4/","display":"DM-Binghamton","name":"DM-Binghamton","slug":"dm-binghamton","status":{"value":"active","label":"Active"},"region":{"id":43,"url":"http://localhost:8041/api/dcim/regions/43/","display":"New
+        York","name":"New York","slug":"us-ny","description":"","site_count":0,"_depth":2},"group":{"id":2,"url":"http://localhost:8041/api/dcim/site-groups/2/","display":"Branch
+        Offices","name":"Branch Offices","slug":"branch-offices","description":"","site_count":0,"_depth":1},"tenant":{"id":5,"url":"http://localhost:8041/api/tenancy/tenants/5/","display":"Dunder-Mifflin,
+        Inc.","name":"Dunder-Mifflin, Inc.","slug":"dunder-mifflin","description":""},"facility":"","time_zone":null,"description":"","physical_address":"","shipping_address":"","latitude":null,"longitude":null,"comments":"","asns":[],"tags":[{"id":7,"url":"http://localhost:8041/api/extras/tags/7/","display_url":"http://localhost:8041/extras/tags/7/","display":"Golf","name":"Golf","slug":"golf","color":"673ab7"},{"id":17,"url":"http://localhost:8041/api/extras/tags/17/","display_url":"http://localhost:8041/extras/tags/17/","display":"Quebec","name":"Quebec","slug":"quebec","color":"cddc39"},{"id":18,"url":"http://localhost:8041/api/extras/tags/18/","display_url":"http://localhost:8041/extras/tags/18/","display":"Romeo","name":"Romeo","slug":"romeo","color":"ffeb3b"}],"custom_fields":{},"created":"2020-12-19T00:00:00Z","last_updated":"2021-12-30T15:45:37.409000Z","circuit_count":2,"device_count":4,"prefix_count":5,"rack_count":1,"virtualmachine_count":0,"vlan_count":3}]}'
+    headers:
+      Allow:
+      - GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS
+      Content-Language:
+      - en
+      Content-Length:
+      - '8095'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - Unit/1.33.0
+      Vary:
+      - HX-Request, Accept-Language, Cookie, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/integration/fixtures/v41/dcim_sites_01/expected.yaml
+++ b/tests/integration/fixtures/v41/dcim_sites_01/expected.yaml
@@ -1,0 +1,79 @@
+# AUTO-GENERATED - DO NOT EDIT
+# This file is generated from definitions.yaml
+# To regenerate: python -m tests.integration.generate_fixtures
+
+definition:
+  id: dcim_sites_01
+  method: dcim_sites
+  args:
+    limit: 5
+call:
+  client_call: dcim_sites
+  client_call_args: []
+  client_call_kwargs:
+    limit: 5
+output: !!python/object:annetbox.base.models.PagingResponse
+  next: http://localhost:8041/api/dcim/sites/?limit=5&offset=5
+  previous: null
+  count: 24
+  results:
+  - !!python/object:annetbox.v41.models.Site
+    id: 24
+    name: Butler Communications
+    display: Butler Communications
+    url: http://localhost:8041/api/dcim/sites/24/
+    slug: ncsu-128
+    status: !!python/object:annetbox.v41.models.Label
+      value: active
+      label: Active
+    custom_fields: {}
+    created: 2021-04-02 00:00:00+00:00
+    last_updated: 2021-12-30 15:45:37.371000+00:00
+  - !!python/object:annetbox.v41.models.Site
+    id: 22
+    name: D. S. Weaver Labs
+    display: D. S. Weaver Labs
+    url: http://localhost:8041/api/dcim/sites/22/
+    slug: ncsu-117
+    status: !!python/object:annetbox.v41.models.Label
+      value: active
+      label: Active
+    custom_fields: {}
+    created: 2021-04-02 00:00:00+00:00
+    last_updated: 2021-12-30 15:45:37.549000+00:00
+  - !!python/object:annetbox.v41.models.Site
+    id: 2
+    name: DM-Akron
+    display: DM-Akron
+    url: http://localhost:8041/api/dcim/sites/2/
+    slug: dm-akron
+    status: !!python/object:annetbox.v41.models.Label
+      value: active
+      label: Active
+    custom_fields: {}
+    created: 2020-12-19 00:00:00+00:00
+    last_updated: 2021-12-30 15:45:37.384000+00:00
+  - !!python/object:annetbox.v41.models.Site
+    id: 3
+    name: DM-Albany
+    display: DM-Albany
+    url: http://localhost:8041/api/dcim/sites/3/
+    slug: dm-albany
+    status: !!python/object:annetbox.v41.models.Label
+      value: active
+      label: Active
+    custom_fields: {}
+    created: 2020-12-19 00:00:00+00:00
+    last_updated: 2021-12-30 15:45:37.397000+00:00
+  - !!python/object:annetbox.v41.models.Site
+    id: 4
+    name: DM-Binghamton
+    display: DM-Binghamton
+    url: http://localhost:8041/api/dcim/sites/4/
+    slug: dm-binghamton
+    status: !!python/object:annetbox.v41.models.Label
+      value: active
+      label: Active
+    custom_fields: {}
+    created: 2020-12-19 00:00:00+00:00
+    last_updated: 2021-12-30 15:45:37.409000+00:00

--- a/tests/integration/fixtures/v41/lock.yaml
+++ b/tests/integration/fixtures/v41/lock.yaml
@@ -99,6 +99,18 @@ test_cases:
     sha256: bb691602478e6a9243d2013e0af244cc4e85b718c3657372e50042509b8ab8aa
   - path: expected.yaml
     sha256: 77470aa44809660a3635de265164b4010b4a5b1a611d37aaf90a5fc9e81fa359
+- test_case: dcim_site_01
+  files:
+  - path: cassette.yaml
+    sha256: 7e8e790690391a8f80bc1a43447c39f1e3126baf9b5cb982d7985522952bee31
+  - path: expected.yaml
+    sha256: 87d71ec80096618164ebe4de1bcbc39d416fd091aae7de1bf6839e9e4fec5ae9
+- test_case: dcim_sites_01
+  files:
+  - path: cassette.yaml
+    sha256: 2f41c19ae0d8943c984349b2fcc3ef442206e839ee93f2246e53f3e1d39a0456
+  - path: expected.yaml
+    sha256: f7a77a2eb82d1a489c659ee7338b374add3075edf95d3944145f2e04fcf167f6
 - test_case: ipam_all_ip_addresses_01
   files:
   - path: cassette.yaml
@@ -117,4 +129,4 @@ test_cases:
     sha256: 63f76435008c461066429fefc49274269b7dd0b8fd2f147732249e36f69e06b1
   - path: expected.yaml
     sha256: 8b15abc0b6415a4fdecf96cb3e7c4a84804e949ca6698475965f62819bf2c4eb
-sha256: e378f35d9630af075cd925314a648a18ebba0e8eab016b6c25fe6be2ef94fea9
+sha256: cfb6afc993e3b1b940c3dbfc8b811aa7062e0676270d9d75da41f52a2301ff41

--- a/tests/integration/fixtures/v42/dcim_site_01/cassette.yaml
+++ b/tests/integration/fixtures/v42/dcim_site_01/cassette.yaml
@@ -1,0 +1,102 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.33.1
+    method: GET
+    uri: http://localhost:8042/api/dcim/sites/?limit=5&offset=0
+  response:
+    body:
+      string: '{"count":24,"next":"http://localhost:8042/api/dcim/sites/?limit=5&offset=5","previous":null,"results":[{"id":24,"url":"http://localhost:8042/api/dcim/sites/24/","display_url":"http://localhost:8042/dcim/sites/24/","display":"Butler
+        Communications","name":"Butler Communications","slug":"ncsu-128","status":{"value":"active","label":"Active"},"region":{"id":40,"url":"http://localhost:8042/api/dcim/regions/40/","display":"North
+        Carolina","name":"North Carolina","slug":"us-nc","description":"","site_count":0,"_depth":2},"group":null,"tenant":{"id":13,"url":"http://localhost:8042/api/tenancy/tenants/13/","display":"NC
+        State University","name":"NC State University","slug":"nc-state","description":""},"facility":"BUT","time_zone":null,"description":"","physical_address":"3210
+        Faucette Dr., Raleigh, NC 27607","shipping_address":"","latitude":null,"longitude":null,"comments":"","asns":[],"tags":[{"id":7,"url":"http://localhost:8042/api/extras/tags/7/","display_url":"http://localhost:8042/extras/tags/7/","display":"Golf","name":"Golf","slug":"golf","color":"673ab7"},{"id":12,"url":"http://localhost:8042/api/extras/tags/12/","display_url":"http://localhost:8042/extras/tags/12/","display":"Lima","name":"Lima","slug":"lima","color":"009688"},{"id":24,"url":"http://localhost:8042/api/extras/tags/24/","display_url":"http://localhost:8042/extras/tags/24/","display":"X-ray","name":"X-ray","slug":"x-ray","color":"9e9e9e"}],"custom_fields":{},"created":"2021-04-02T00:00:00Z","last_updated":"2021-12-30T15:45:37.371000Z","circuit_count":1,"device_count":2,"prefix_count":0,"rack_count":1,"virtualmachine_count":0,"vlan_count":0},{"id":22,"url":"http://localhost:8042/api/dcim/sites/22/","display_url":"http://localhost:8042/dcim/sites/22/","display":"D.
+        S. Weaver Labs","name":"D. S. Weaver Labs","slug":"ncsu-117","status":{"value":"active","label":"Active"},"region":{"id":40,"url":"http://localhost:8042/api/dcim/regions/40/","display":"North
+        Carolina","name":"North Carolina","slug":"us-nc","description":"","site_count":0,"_depth":2},"group":null,"tenant":{"id":13,"url":"http://localhost:8042/api/tenancy/tenants/13/","display":"NC
+        State University","name":"NC State University","slug":"nc-state","description":""},"facility":"DSW","time_zone":null,"description":"","physical_address":"3110
+        Faucette Dr., Raleigh, NC 27607","shipping_address":"","latitude":null,"longitude":null,"comments":"","asns":[],"tags":[{"id":17,"url":"http://localhost:8042/api/extras/tags/17/","display_url":"http://localhost:8042/extras/tags/17/","display":"Quebec","name":"Quebec","slug":"quebec","color":"cddc39"},{"id":20,"url":"http://localhost:8042/api/extras/tags/20/","display_url":"http://localhost:8042/extras/tags/20/","display":"Tango","name":"Tango","slug":"tango","color":"ff9800"},{"id":24,"url":"http://localhost:8042/api/extras/tags/24/","display_url":"http://localhost:8042/extras/tags/24/","display":"X-ray","name":"X-ray","slug":"x-ray","color":"9e9e9e"}],"custom_fields":{},"created":"2021-04-02T00:00:00Z","last_updated":"2021-12-30T15:45:37.549000Z","circuit_count":1,"device_count":2,"prefix_count":0,"rack_count":1,"virtualmachine_count":0,"vlan_count":0},{"id":2,"url":"http://localhost:8042/api/dcim/sites/2/","display_url":"http://localhost:8042/dcim/sites/2/","display":"DM-Akron","name":"DM-Akron","slug":"dm-akron","status":{"value":"active","label":"Active"},"region":{"id":51,"url":"http://localhost:8042/api/dcim/regions/51/","display":"Ohio","name":"Ohio","slug":"us-oh","description":"","site_count":0,"_depth":2},"group":{"id":2,"url":"http://localhost:8042/api/dcim/site-groups/2/","display":"Branch
+        Offices","name":"Branch Offices","slug":"branch-offices","description":"","site_count":0,"_depth":1},"tenant":{"id":5,"url":"http://localhost:8042/api/tenancy/tenants/5/","display":"Dunder-Mifflin,
+        Inc.","name":"Dunder-Mifflin, Inc.","slug":"dunder-mifflin","description":""},"facility":"","time_zone":null,"description":"","physical_address":"","shipping_address":"","latitude":null,"longitude":null,"comments":"","asns":[],"tags":[{"id":1,"url":"http://localhost:8042/api/extras/tags/1/","display_url":"http://localhost:8042/extras/tags/1/","display":"Alpha","name":"Alpha","slug":"alpha","color":"aa1409"},{"id":2,"url":"http://localhost:8042/api/extras/tags/2/","display_url":"http://localhost:8042/extras/tags/2/","display":"Bravo","name":"Bravo","slug":"bravo","color":"f44336"},{"id":7,"url":"http://localhost:8042/api/extras/tags/7/","display_url":"http://localhost:8042/extras/tags/7/","display":"Golf","name":"Golf","slug":"golf","color":"673ab7"}],"custom_fields":{},"created":"2020-12-19T00:00:00Z","last_updated":"2021-12-30T15:45:37.384000Z","circuit_count":2,"device_count":4,"prefix_count":5,"rack_count":1,"virtualmachine_count":0,"vlan_count":3},{"id":3,"url":"http://localhost:8042/api/dcim/sites/3/","display_url":"http://localhost:8042/dcim/sites/3/","display":"DM-Albany","name":"DM-Albany","slug":"dm-albany","status":{"value":"active","label":"Active"},"region":{"id":43,"url":"http://localhost:8042/api/dcim/regions/43/","display":"New
+        York","name":"New York","slug":"us-ny","description":"","site_count":0,"_depth":2},"group":{"id":2,"url":"http://localhost:8042/api/dcim/site-groups/2/","display":"Branch
+        Offices","name":"Branch Offices","slug":"branch-offices","description":"","site_count":0,"_depth":1},"tenant":{"id":5,"url":"http://localhost:8042/api/tenancy/tenants/5/","display":"Dunder-Mifflin,
+        Inc.","name":"Dunder-Mifflin, Inc.","slug":"dunder-mifflin","description":""},"facility":"","time_zone":null,"description":"","physical_address":"","shipping_address":"","latitude":null,"longitude":null,"comments":"","asns":[],"tags":[{"id":3,"url":"http://localhost:8042/api/extras/tags/3/","display_url":"http://localhost:8042/extras/tags/3/","display":"Charlie","name":"Charlie","slug":"charlie","color":"e91e63"},{"id":14,"url":"http://localhost:8042/api/extras/tags/14/","display_url":"http://localhost:8042/extras/tags/14/","display":"November","name":"November","slug":"november","color":"2f6a31"},{"id":16,"url":"http://localhost:8042/api/extras/tags/16/","display_url":"http://localhost:8042/extras/tags/16/","display":"Papa","name":"Papa","slug":"papa","color":"8bc34a"}],"custom_fields":{},"created":"2020-12-19T00:00:00Z","last_updated":"2021-12-30T15:45:37.397000Z","circuit_count":2,"device_count":4,"prefix_count":5,"rack_count":1,"virtualmachine_count":0,"vlan_count":3},{"id":4,"url":"http://localhost:8042/api/dcim/sites/4/","display_url":"http://localhost:8042/dcim/sites/4/","display":"DM-Binghamton","name":"DM-Binghamton","slug":"dm-binghamton","status":{"value":"active","label":"Active"},"region":{"id":43,"url":"http://localhost:8042/api/dcim/regions/43/","display":"New
+        York","name":"New York","slug":"us-ny","description":"","site_count":0,"_depth":2},"group":{"id":2,"url":"http://localhost:8042/api/dcim/site-groups/2/","display":"Branch
+        Offices","name":"Branch Offices","slug":"branch-offices","description":"","site_count":0,"_depth":1},"tenant":{"id":5,"url":"http://localhost:8042/api/tenancy/tenants/5/","display":"Dunder-Mifflin,
+        Inc.","name":"Dunder-Mifflin, Inc.","slug":"dunder-mifflin","description":""},"facility":"","time_zone":null,"description":"","physical_address":"","shipping_address":"","latitude":null,"longitude":null,"comments":"","asns":[],"tags":[{"id":7,"url":"http://localhost:8042/api/extras/tags/7/","display_url":"http://localhost:8042/extras/tags/7/","display":"Golf","name":"Golf","slug":"golf","color":"673ab7"},{"id":17,"url":"http://localhost:8042/api/extras/tags/17/","display_url":"http://localhost:8042/extras/tags/17/","display":"Quebec","name":"Quebec","slug":"quebec","color":"cddc39"},{"id":18,"url":"http://localhost:8042/api/extras/tags/18/","display_url":"http://localhost:8042/extras/tags/18/","display":"Romeo","name":"Romeo","slug":"romeo","color":"ffeb3b"}],"custom_fields":{},"created":"2020-12-19T00:00:00Z","last_updated":"2021-12-30T15:45:37.409000Z","circuit_count":2,"device_count":4,"prefix_count":5,"rack_count":1,"virtualmachine_count":0,"vlan_count":3}]}'
+    headers:
+      Allow:
+      - GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS
+      Content-Language:
+      - en
+      Content-Length:
+      - '8095'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - Unit/1.34.1
+      Vary:
+      - HX-Request, Accept-Language, Cookie, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.33.1
+    method: GET
+    uri: http://localhost:8042/api/dcim/sites/24/
+  response:
+    body:
+      string: '{"id":24,"url":"http://localhost:8042/api/dcim/sites/24/","display_url":"http://localhost:8042/dcim/sites/24/","display":"Butler
+        Communications","name":"Butler Communications","slug":"ncsu-128","status":{"value":"active","label":"Active"},"region":{"id":40,"url":"http://localhost:8042/api/dcim/regions/40/","display":"North
+        Carolina","name":"North Carolina","slug":"us-nc","description":"","site_count":0,"_depth":2},"group":null,"tenant":{"id":13,"url":"http://localhost:8042/api/tenancy/tenants/13/","display":"NC
+        State University","name":"NC State University","slug":"nc-state","description":""},"facility":"BUT","time_zone":null,"description":"","physical_address":"3210
+        Faucette Dr., Raleigh, NC 27607","shipping_address":"","latitude":null,"longitude":null,"comments":"","asns":[],"tags":[{"id":7,"url":"http://localhost:8042/api/extras/tags/7/","display_url":"http://localhost:8042/extras/tags/7/","display":"Golf","name":"Golf","slug":"golf","color":"673ab7"},{"id":12,"url":"http://localhost:8042/api/extras/tags/12/","display_url":"http://localhost:8042/extras/tags/12/","display":"Lima","name":"Lima","slug":"lima","color":"009688"},{"id":24,"url":"http://localhost:8042/api/extras/tags/24/","display_url":"http://localhost:8042/extras/tags/24/","display":"X-ray","name":"X-ray","slug":"x-ray","color":"9e9e9e"}],"custom_fields":{},"created":"2021-04-02T00:00:00Z","last_updated":"2021-12-30T15:45:37.371000Z","circuit_count":1,"device_count":2,"prefix_count":0,"rack_count":1,"virtualmachine_count":0,"vlan_count":0}'
+    headers:
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      Content-Language:
+      - en
+      Content-Length:
+      - '1529'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - Unit/1.34.1
+      Vary:
+      - HX-Request, Accept-Language, Cookie, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/integration/fixtures/v42/dcim_site_01/expected.yaml
+++ b/tests/integration/fixtures/v42/dcim_site_01/expected.yaml
@@ -1,0 +1,30 @@
+# AUTO-GENERATED - DO NOT EDIT
+# This file is generated from definitions.yaml
+# To regenerate: python -m tests.integration.generate_fixtures
+
+definition:
+  id: dcim_site_01
+  method: dcim_site
+  args:
+    site_id:
+      call: dcim_sites
+      args:
+        limit: 5
+      extract: results[0].id
+call:
+  client_call: dcim_site
+  client_call_args: []
+  client_call_kwargs:
+    site_id: 24
+output: !!python/object:annetbox.v42.models.Site
+  id: 24
+  name: Butler Communications
+  display: Butler Communications
+  url: http://localhost:8042/api/dcim/sites/24/
+  slug: ncsu-128
+  status: !!python/object:annetbox.v42.models.Label
+    value: active
+    label: Active
+  custom_fields: {}
+  created: 2021-04-02 00:00:00+00:00
+  last_updated: 2021-12-30 15:45:37.371000+00:00

--- a/tests/integration/fixtures/v42/dcim_sites_01/cassette.yaml
+++ b/tests/integration/fixtures/v42/dcim_sites_01/cassette.yaml
@@ -1,0 +1,58 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.33.1
+    method: GET
+    uri: http://localhost:8042/api/dcim/sites/?limit=5&offset=0
+  response:
+    body:
+      string: '{"count":24,"next":"http://localhost:8042/api/dcim/sites/?limit=5&offset=5","previous":null,"results":[{"id":24,"url":"http://localhost:8042/api/dcim/sites/24/","display_url":"http://localhost:8042/dcim/sites/24/","display":"Butler
+        Communications","name":"Butler Communications","slug":"ncsu-128","status":{"value":"active","label":"Active"},"region":{"id":40,"url":"http://localhost:8042/api/dcim/regions/40/","display":"North
+        Carolina","name":"North Carolina","slug":"us-nc","description":"","site_count":0,"_depth":2},"group":null,"tenant":{"id":13,"url":"http://localhost:8042/api/tenancy/tenants/13/","display":"NC
+        State University","name":"NC State University","slug":"nc-state","description":""},"facility":"BUT","time_zone":null,"description":"","physical_address":"3210
+        Faucette Dr., Raleigh, NC 27607","shipping_address":"","latitude":null,"longitude":null,"comments":"","asns":[],"tags":[{"id":7,"url":"http://localhost:8042/api/extras/tags/7/","display_url":"http://localhost:8042/extras/tags/7/","display":"Golf","name":"Golf","slug":"golf","color":"673ab7"},{"id":12,"url":"http://localhost:8042/api/extras/tags/12/","display_url":"http://localhost:8042/extras/tags/12/","display":"Lima","name":"Lima","slug":"lima","color":"009688"},{"id":24,"url":"http://localhost:8042/api/extras/tags/24/","display_url":"http://localhost:8042/extras/tags/24/","display":"X-ray","name":"X-ray","slug":"x-ray","color":"9e9e9e"}],"custom_fields":{},"created":"2021-04-02T00:00:00Z","last_updated":"2021-12-30T15:45:37.371000Z","circuit_count":1,"device_count":2,"prefix_count":0,"rack_count":1,"virtualmachine_count":0,"vlan_count":0},{"id":22,"url":"http://localhost:8042/api/dcim/sites/22/","display_url":"http://localhost:8042/dcim/sites/22/","display":"D.
+        S. Weaver Labs","name":"D. S. Weaver Labs","slug":"ncsu-117","status":{"value":"active","label":"Active"},"region":{"id":40,"url":"http://localhost:8042/api/dcim/regions/40/","display":"North
+        Carolina","name":"North Carolina","slug":"us-nc","description":"","site_count":0,"_depth":2},"group":null,"tenant":{"id":13,"url":"http://localhost:8042/api/tenancy/tenants/13/","display":"NC
+        State University","name":"NC State University","slug":"nc-state","description":""},"facility":"DSW","time_zone":null,"description":"","physical_address":"3110
+        Faucette Dr., Raleigh, NC 27607","shipping_address":"","latitude":null,"longitude":null,"comments":"","asns":[],"tags":[{"id":17,"url":"http://localhost:8042/api/extras/tags/17/","display_url":"http://localhost:8042/extras/tags/17/","display":"Quebec","name":"Quebec","slug":"quebec","color":"cddc39"},{"id":20,"url":"http://localhost:8042/api/extras/tags/20/","display_url":"http://localhost:8042/extras/tags/20/","display":"Tango","name":"Tango","slug":"tango","color":"ff9800"},{"id":24,"url":"http://localhost:8042/api/extras/tags/24/","display_url":"http://localhost:8042/extras/tags/24/","display":"X-ray","name":"X-ray","slug":"x-ray","color":"9e9e9e"}],"custom_fields":{},"created":"2021-04-02T00:00:00Z","last_updated":"2021-12-30T15:45:37.549000Z","circuit_count":1,"device_count":2,"prefix_count":0,"rack_count":1,"virtualmachine_count":0,"vlan_count":0},{"id":2,"url":"http://localhost:8042/api/dcim/sites/2/","display_url":"http://localhost:8042/dcim/sites/2/","display":"DM-Akron","name":"DM-Akron","slug":"dm-akron","status":{"value":"active","label":"Active"},"region":{"id":51,"url":"http://localhost:8042/api/dcim/regions/51/","display":"Ohio","name":"Ohio","slug":"us-oh","description":"","site_count":0,"_depth":2},"group":{"id":2,"url":"http://localhost:8042/api/dcim/site-groups/2/","display":"Branch
+        Offices","name":"Branch Offices","slug":"branch-offices","description":"","site_count":0,"_depth":1},"tenant":{"id":5,"url":"http://localhost:8042/api/tenancy/tenants/5/","display":"Dunder-Mifflin,
+        Inc.","name":"Dunder-Mifflin, Inc.","slug":"dunder-mifflin","description":""},"facility":"","time_zone":null,"description":"","physical_address":"","shipping_address":"","latitude":null,"longitude":null,"comments":"","asns":[],"tags":[{"id":1,"url":"http://localhost:8042/api/extras/tags/1/","display_url":"http://localhost:8042/extras/tags/1/","display":"Alpha","name":"Alpha","slug":"alpha","color":"aa1409"},{"id":2,"url":"http://localhost:8042/api/extras/tags/2/","display_url":"http://localhost:8042/extras/tags/2/","display":"Bravo","name":"Bravo","slug":"bravo","color":"f44336"},{"id":7,"url":"http://localhost:8042/api/extras/tags/7/","display_url":"http://localhost:8042/extras/tags/7/","display":"Golf","name":"Golf","slug":"golf","color":"673ab7"}],"custom_fields":{},"created":"2020-12-19T00:00:00Z","last_updated":"2021-12-30T15:45:37.384000Z","circuit_count":2,"device_count":4,"prefix_count":5,"rack_count":1,"virtualmachine_count":0,"vlan_count":3},{"id":3,"url":"http://localhost:8042/api/dcim/sites/3/","display_url":"http://localhost:8042/dcim/sites/3/","display":"DM-Albany","name":"DM-Albany","slug":"dm-albany","status":{"value":"active","label":"Active"},"region":{"id":43,"url":"http://localhost:8042/api/dcim/regions/43/","display":"New
+        York","name":"New York","slug":"us-ny","description":"","site_count":0,"_depth":2},"group":{"id":2,"url":"http://localhost:8042/api/dcim/site-groups/2/","display":"Branch
+        Offices","name":"Branch Offices","slug":"branch-offices","description":"","site_count":0,"_depth":1},"tenant":{"id":5,"url":"http://localhost:8042/api/tenancy/tenants/5/","display":"Dunder-Mifflin,
+        Inc.","name":"Dunder-Mifflin, Inc.","slug":"dunder-mifflin","description":""},"facility":"","time_zone":null,"description":"","physical_address":"","shipping_address":"","latitude":null,"longitude":null,"comments":"","asns":[],"tags":[{"id":3,"url":"http://localhost:8042/api/extras/tags/3/","display_url":"http://localhost:8042/extras/tags/3/","display":"Charlie","name":"Charlie","slug":"charlie","color":"e91e63"},{"id":14,"url":"http://localhost:8042/api/extras/tags/14/","display_url":"http://localhost:8042/extras/tags/14/","display":"November","name":"November","slug":"november","color":"2f6a31"},{"id":16,"url":"http://localhost:8042/api/extras/tags/16/","display_url":"http://localhost:8042/extras/tags/16/","display":"Papa","name":"Papa","slug":"papa","color":"8bc34a"}],"custom_fields":{},"created":"2020-12-19T00:00:00Z","last_updated":"2021-12-30T15:45:37.397000Z","circuit_count":2,"device_count":4,"prefix_count":5,"rack_count":1,"virtualmachine_count":0,"vlan_count":3},{"id":4,"url":"http://localhost:8042/api/dcim/sites/4/","display_url":"http://localhost:8042/dcim/sites/4/","display":"DM-Binghamton","name":"DM-Binghamton","slug":"dm-binghamton","status":{"value":"active","label":"Active"},"region":{"id":43,"url":"http://localhost:8042/api/dcim/regions/43/","display":"New
+        York","name":"New York","slug":"us-ny","description":"","site_count":0,"_depth":2},"group":{"id":2,"url":"http://localhost:8042/api/dcim/site-groups/2/","display":"Branch
+        Offices","name":"Branch Offices","slug":"branch-offices","description":"","site_count":0,"_depth":1},"tenant":{"id":5,"url":"http://localhost:8042/api/tenancy/tenants/5/","display":"Dunder-Mifflin,
+        Inc.","name":"Dunder-Mifflin, Inc.","slug":"dunder-mifflin","description":""},"facility":"","time_zone":null,"description":"","physical_address":"","shipping_address":"","latitude":null,"longitude":null,"comments":"","asns":[],"tags":[{"id":7,"url":"http://localhost:8042/api/extras/tags/7/","display_url":"http://localhost:8042/extras/tags/7/","display":"Golf","name":"Golf","slug":"golf","color":"673ab7"},{"id":17,"url":"http://localhost:8042/api/extras/tags/17/","display_url":"http://localhost:8042/extras/tags/17/","display":"Quebec","name":"Quebec","slug":"quebec","color":"cddc39"},{"id":18,"url":"http://localhost:8042/api/extras/tags/18/","display_url":"http://localhost:8042/extras/tags/18/","display":"Romeo","name":"Romeo","slug":"romeo","color":"ffeb3b"}],"custom_fields":{},"created":"2020-12-19T00:00:00Z","last_updated":"2021-12-30T15:45:37.409000Z","circuit_count":2,"device_count":4,"prefix_count":5,"rack_count":1,"virtualmachine_count":0,"vlan_count":3}]}'
+    headers:
+      Allow:
+      - GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS
+      Content-Language:
+      - en
+      Content-Length:
+      - '8095'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - Unit/1.34.1
+      Vary:
+      - HX-Request, Accept-Language, Cookie, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/integration/fixtures/v42/dcim_sites_01/expected.yaml
+++ b/tests/integration/fixtures/v42/dcim_sites_01/expected.yaml
@@ -1,0 +1,79 @@
+# AUTO-GENERATED - DO NOT EDIT
+# This file is generated from definitions.yaml
+# To regenerate: python -m tests.integration.generate_fixtures
+
+definition:
+  id: dcim_sites_01
+  method: dcim_sites
+  args:
+    limit: 5
+call:
+  client_call: dcim_sites
+  client_call_args: []
+  client_call_kwargs:
+    limit: 5
+output: !!python/object:annetbox.base.models.PagingResponse
+  next: http://localhost:8042/api/dcim/sites/?limit=5&offset=5
+  previous: null
+  count: 24
+  results:
+  - !!python/object:annetbox.v42.models.Site
+    id: 24
+    name: Butler Communications
+    display: Butler Communications
+    url: http://localhost:8042/api/dcim/sites/24/
+    slug: ncsu-128
+    status: !!python/object:annetbox.v42.models.Label
+      value: active
+      label: Active
+    custom_fields: {}
+    created: 2021-04-02 00:00:00+00:00
+    last_updated: 2021-12-30 15:45:37.371000+00:00
+  - !!python/object:annetbox.v42.models.Site
+    id: 22
+    name: D. S. Weaver Labs
+    display: D. S. Weaver Labs
+    url: http://localhost:8042/api/dcim/sites/22/
+    slug: ncsu-117
+    status: !!python/object:annetbox.v42.models.Label
+      value: active
+      label: Active
+    custom_fields: {}
+    created: 2021-04-02 00:00:00+00:00
+    last_updated: 2021-12-30 15:45:37.549000+00:00
+  - !!python/object:annetbox.v42.models.Site
+    id: 2
+    name: DM-Akron
+    display: DM-Akron
+    url: http://localhost:8042/api/dcim/sites/2/
+    slug: dm-akron
+    status: !!python/object:annetbox.v42.models.Label
+      value: active
+      label: Active
+    custom_fields: {}
+    created: 2020-12-19 00:00:00+00:00
+    last_updated: 2021-12-30 15:45:37.384000+00:00
+  - !!python/object:annetbox.v42.models.Site
+    id: 3
+    name: DM-Albany
+    display: DM-Albany
+    url: http://localhost:8042/api/dcim/sites/3/
+    slug: dm-albany
+    status: !!python/object:annetbox.v42.models.Label
+      value: active
+      label: Active
+    custom_fields: {}
+    created: 2020-12-19 00:00:00+00:00
+    last_updated: 2021-12-30 15:45:37.397000+00:00
+  - !!python/object:annetbox.v42.models.Site
+    id: 4
+    name: DM-Binghamton
+    display: DM-Binghamton
+    url: http://localhost:8042/api/dcim/sites/4/
+    slug: dm-binghamton
+    status: !!python/object:annetbox.v42.models.Label
+      value: active
+      label: Active
+    custom_fields: {}
+    created: 2020-12-19 00:00:00+00:00
+    last_updated: 2021-12-30 15:45:37.409000+00:00

--- a/tests/integration/fixtures/v42/lock.yaml
+++ b/tests/integration/fixtures/v42/lock.yaml
@@ -99,6 +99,18 @@ test_cases:
     sha256: b79e8c3f8013023ccbe5387253e9bee7683f2dcd78f944cf6ac9b06ea0f1319d
   - path: expected.yaml
     sha256: cb15c821321b0959d45f0e30d2ec16e776d02ea0e45f30cea99827aa5cebefba
+- test_case: dcim_site_01
+  files:
+  - path: cassette.yaml
+    sha256: 5525c1fcb849bc5fd949ab72022d07efa662872ac864931cacbe9a8d7e16322a
+  - path: expected.yaml
+    sha256: e957cb14ca8051ecd5562183fad1c114fe1dbbf2d07a2c62a7975552096fa7af
+- test_case: dcim_sites_01
+  files:
+  - path: cassette.yaml
+    sha256: 6c063de6f3191a41877e0f6e80e46ab49e52049bc0d88d04a800d898569e6045
+  - path: expected.yaml
+    sha256: ede96f17e9a8ae662bd6ce97020d81e73b1a603c707d96b48405d250fbe966cb
 - test_case: ipam_all_ip_addresses_01
   files:
   - path: cassette.yaml
@@ -123,4 +135,4 @@ test_cases:
     sha256: af34f1f6d64d1eac75e9aa6ebf0777214af261846a691ac5b147989077cb790d
   - path: expected.yaml
     sha256: 880e42c46cd1dff42ec6f389ad6c0b128b380d18371d11bf7e5e1871e1a44237
-sha256: 165abd23a25fce1f07dcc8bcbcbf2f8bb746a6434fbdcace683b11bce1772cfd
+sha256: da854aceba63221173b64b47c0296a558d2cbb139f8070e68c1a0056f51ffb98


### PR DESCRIPTION
## Summary
- Adds `Site` dataclass + `dcim_site`, `dcim_sites`, `dcim_all_sites` to v37, v41, v42 (sync + async).
- Closes the gap where the typed client only exposed the inline `{id, name, slug}` Site stub on
`Device.site`.
- Sync clients regenerated via `transform_to_sync.py`.

## Test plan
- [x] `pytest tests/integration/` (definitions + cassettes + lock.yaml hashes for `dcim_site_01` and
`dcim_sites_01` across v37/v41/v42)
- [x] Sync clients verified byte-identical to `transform_to_sync.py` output
- [x] `ruff check .` — no new findings from this change
