### PR TITLE
fix: Async vcrpy tests are broken with aiohttp==3.14.0

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,5 @@
 ruff==0.4.*
+aiohttp<3.14.0  # 3.14.0 removed aiohttp.streams.AsyncStreamReaderMixin which breaks vcrpy
 pytest==8.*
 pytest-asyncio==1.3.*
 vcrpy==8.*


### PR DESCRIPTION
aiohttp removed an mixin https://github.com/pydantic/pydantic-ai/issues/5751

For now lets pin the version of aiohttp for tests until there is a compatible version.
