### PR TITLE
    feat: add dcim regions, site groups, locations and tenancy tenant groups

### DIFF
--- a/src/annetbox/v37/client_async.py
+++ b/src/annetbox/v37/client_async.py
@@ -19,9 +19,13 @@ from .models import (
     Interface,
     IpAddress,
     ItemToDelete,
+    Location,
     NewCable,
     Prefix,
+    Region,
     Site,
+    SiteGroup,
+    TenantGroup,
     TraceTuple,
 )
 
@@ -222,6 +226,90 @@ class NetboxV37(BaseNetboxClient):
 
     @get("dcim/sites/{site_id}/")
     async def dcim_site(self, site_id: int) -> Site:
+        pass
+
+    @get("dcim/regions/")
+    async def dcim_regions(
+        self,
+        id: list[int] | None = None,
+        name: list[str] | None = None,
+        slug: list[str] | None = None,
+        tag: list[str] | None = None,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> PagingResponse[Region]:
+        pass
+
+    dcim_all_regions = collect(dcim_regions)
+    dcim_all_regions_by_id = collect(dcim_regions, field="id")
+
+    @get("dcim/regions/{region_id}/")
+    async def dcim_region(self, region_id: int) -> Region:
+        pass
+
+    @get("dcim/site-groups/")
+    async def dcim_site_groups(
+        self,
+        id: list[int] | None = None,
+        name: list[str] | None = None,
+        slug: list[str] | None = None,
+        tag: list[str] | None = None,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> PagingResponse[SiteGroup]:
+        pass
+
+    dcim_all_site_groups = collect(dcim_site_groups)
+    dcim_all_site_groups_by_id = collect(dcim_site_groups, field="id")
+
+    @get("dcim/site-groups/{site_group_id}/")
+    async def dcim_site_group(self, site_group_id: int) -> SiteGroup:
+        pass
+
+    @get("dcim/locations/")
+    async def dcim_locations(
+        self,
+        id: list[int] | None = None,
+        name: list[str] | None = None,
+        slug: list[str] | None = None,
+        site: list[str] | None = None,
+        site_id: list[int] | None = None,
+        parent: list[str] | None = None,
+        parent_id: list[int] | None = None,
+        status: list[str] | None = None,
+        tenant: list[str] | None = None,
+        tag: list[str] | None = None,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> PagingResponse[Location]:
+        pass
+
+    dcim_all_locations = collect(dcim_locations)
+    dcim_all_locations_by_id = collect(dcim_locations, field="id")
+
+    @get("dcim/locations/{location_id}/")
+    async def dcim_location(self, location_id: int) -> Location:
+        pass
+
+    @get("tenancy/tenant-groups/")
+    async def tenancy_tenant_groups(
+        self,
+        id: list[int] | None = None,
+        name: list[str] | None = None,
+        slug: list[str] | None = None,
+        tag: list[str] | None = None,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> PagingResponse[TenantGroup]:
+        pass
+
+    tenancy_all_tenant_groups = collect(tenancy_tenant_groups)
+    tenancy_all_tenant_groups_by_id = collect(
+        tenancy_tenant_groups, field="id",
+    )
+
+    @get("tenancy/tenant-groups/{tenant_group_id}/")
+    async def tenancy_tenant_group(self, tenant_group_id: int) -> TenantGroup:
         pass
 
     # ipam

--- a/src/annetbox/v37/client_sync.py
+++ b/src/annetbox/v37/client_sync.py
@@ -19,9 +19,13 @@ from .models import (
     Interface,
     IpAddress,
     ItemToDelete,
+    Location,
     NewCable,
     Prefix,
+    Region,
     Site,
+    SiteGroup,
+    TenantGroup,
     TraceTuple,
 )
 
@@ -222,6 +226,90 @@ class NetboxV37(BaseNetboxClient):
 
     @get("dcim/sites/{site_id}/")
     def dcim_site(self, site_id: int) -> Site:
+        pass
+
+    @get("dcim/regions/")
+    def dcim_regions(
+        self,
+        id: list[int] | None = None,
+        name: list[str] | None = None,
+        slug: list[str] | None = None,
+        tag: list[str] | None = None,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> PagingResponse[Region]:
+        pass
+
+    dcim_all_regions = collect(dcim_regions)
+    dcim_all_regions_by_id = collect(dcim_regions, field="id")
+
+    @get("dcim/regions/{region_id}/")
+    def dcim_region(self, region_id: int) -> Region:
+        pass
+
+    @get("dcim/site-groups/")
+    def dcim_site_groups(
+        self,
+        id: list[int] | None = None,
+        name: list[str] | None = None,
+        slug: list[str] | None = None,
+        tag: list[str] | None = None,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> PagingResponse[SiteGroup]:
+        pass
+
+    dcim_all_site_groups = collect(dcim_site_groups)
+    dcim_all_site_groups_by_id = collect(dcim_site_groups, field="id")
+
+    @get("dcim/site-groups/{site_group_id}/")
+    def dcim_site_group(self, site_group_id: int) -> SiteGroup:
+        pass
+
+    @get("dcim/locations/")
+    def dcim_locations(
+        self,
+        id: list[int] | None = None,
+        name: list[str] | None = None,
+        slug: list[str] | None = None,
+        site: list[str] | None = None,
+        site_id: list[int] | None = None,
+        parent: list[str] | None = None,
+        parent_id: list[int] | None = None,
+        status: list[str] | None = None,
+        tenant: list[str] | None = None,
+        tag: list[str] | None = None,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> PagingResponse[Location]:
+        pass
+
+    dcim_all_locations = collect(dcim_locations)
+    dcim_all_locations_by_id = collect(dcim_locations, field="id")
+
+    @get("dcim/locations/{location_id}/")
+    def dcim_location(self, location_id: int) -> Location:
+        pass
+
+    @get("tenancy/tenant-groups/")
+    def tenancy_tenant_groups(
+        self,
+        id: list[int] | None = None,
+        name: list[str] | None = None,
+        slug: list[str] | None = None,
+        tag: list[str] | None = None,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> PagingResponse[TenantGroup]:
+        pass
+
+    tenancy_all_tenant_groups = collect(tenancy_tenant_groups)
+    tenancy_all_tenant_groups_by_id = collect(
+        tenancy_tenant_groups, field="id",
+    )
+
+    @get("tenancy/tenant-groups/{tenant_group_id}/")
+    def tenancy_tenant_group(self, tenant_group_id: int) -> TenantGroup:
         pass
 
     # ipam

--- a/src/annetbox/v37/models.py
+++ b/src/annetbox/v37/models.py
@@ -146,6 +146,46 @@ class Site(Entity):
 
 
 @dataclass
+class Region(EntityWithSlug):
+    description: str
+    custom_fields: dict[str, Any]
+    created: datetime
+    last_updated: datetime
+    parent: EntityWithSlug | None = None
+
+
+@dataclass
+class SiteGroup(EntityWithSlug):
+    description: str
+    custom_fields: dict[str, Any]
+    created: datetime
+    last_updated: datetime
+    parent: EntityWithSlug | None = None
+
+
+@dataclass
+class Location(EntityWithSlug):
+    site: Entity
+    status: Label
+    description: str
+    custom_fields: dict[str, Any]
+    created: datetime
+    last_updated: datetime
+    parent: EntityWithSlug | None = None
+    tenant: EntityWithSlug | None = None
+    facility: str = ""
+
+
+@dataclass
+class TenantGroup(EntityWithSlug):
+    description: str
+    custom_fields: dict[str, Any]
+    created: datetime
+    last_updated: datetime
+    parent: EntityWithSlug | None = None
+
+
+@dataclass
 class Device(Entity):
     url: str
     display: str  # renamed in 3.x from display_name

--- a/src/annetbox/v41/client_async.py
+++ b/src/annetbox/v41/client_async.py
@@ -19,9 +19,13 @@ from .models import (
     Interface,
     IpAddress,
     ItemToDelete,
+    Location,
     NewCable,
     Prefix,
+    Region,
     Site,
+    SiteGroup,
+    TenantGroup,
     TraceTuple,
 )
 
@@ -222,6 +226,90 @@ class NetboxV41(BaseNetboxClient):
 
     @get("dcim/sites/{site_id}/")
     async def dcim_site(self, site_id: int) -> Site:
+        pass
+
+    @get("dcim/regions/")
+    async def dcim_regions(
+        self,
+        id: list[int] | None = None,
+        name: list[str] | None = None,
+        slug: list[str] | None = None,
+        tag: list[str] | None = None,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> PagingResponse[Region]:
+        pass
+
+    dcim_all_regions = collect(dcim_regions)
+    dcim_all_regions_by_id = collect(dcim_regions, field="id")
+
+    @get("dcim/regions/{region_id}/")
+    async def dcim_region(self, region_id: int) -> Region:
+        pass
+
+    @get("dcim/site-groups/")
+    async def dcim_site_groups(
+        self,
+        id: list[int] | None = None,
+        name: list[str] | None = None,
+        slug: list[str] | None = None,
+        tag: list[str] | None = None,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> PagingResponse[SiteGroup]:
+        pass
+
+    dcim_all_site_groups = collect(dcim_site_groups)
+    dcim_all_site_groups_by_id = collect(dcim_site_groups, field="id")
+
+    @get("dcim/site-groups/{site_group_id}/")
+    async def dcim_site_group(self, site_group_id: int) -> SiteGroup:
+        pass
+
+    @get("dcim/locations/")
+    async def dcim_locations(
+        self,
+        id: list[int] | None = None,
+        name: list[str] | None = None,
+        slug: list[str] | None = None,
+        site: list[str] | None = None,
+        site_id: list[int] | None = None,
+        parent: list[str] | None = None,
+        parent_id: list[int] | None = None,
+        status: list[str] | None = None,
+        tenant: list[str] | None = None,
+        tag: list[str] | None = None,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> PagingResponse[Location]:
+        pass
+
+    dcim_all_locations = collect(dcim_locations)
+    dcim_all_locations_by_id = collect(dcim_locations, field="id")
+
+    @get("dcim/locations/{location_id}/")
+    async def dcim_location(self, location_id: int) -> Location:
+        pass
+
+    @get("tenancy/tenant-groups/")
+    async def tenancy_tenant_groups(
+        self,
+        id: list[int] | None = None,
+        name: list[str] | None = None,
+        slug: list[str] | None = None,
+        tag: list[str] | None = None,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> PagingResponse[TenantGroup]:
+        pass
+
+    tenancy_all_tenant_groups = collect(tenancy_tenant_groups)
+    tenancy_all_tenant_groups_by_id = collect(
+        tenancy_tenant_groups, field="id",
+    )
+
+    @get("tenancy/tenant-groups/{tenant_group_id}/")
+    async def tenancy_tenant_group(self, tenant_group_id: int) -> TenantGroup:
         pass
 
     # ipam

--- a/src/annetbox/v41/client_sync.py
+++ b/src/annetbox/v41/client_sync.py
@@ -19,9 +19,13 @@ from .models import (
     Interface,
     IpAddress,
     ItemToDelete,
+    Location,
     NewCable,
     Prefix,
+    Region,
     Site,
+    SiteGroup,
+    TenantGroup,
     TraceTuple,
 )
 
@@ -222,6 +226,90 @@ class NetboxV41(BaseNetboxClient):
 
     @get("dcim/sites/{site_id}/")
     def dcim_site(self, site_id: int) -> Site:
+        pass
+
+    @get("dcim/regions/")
+    def dcim_regions(
+        self,
+        id: list[int] | None = None,
+        name: list[str] | None = None,
+        slug: list[str] | None = None,
+        tag: list[str] | None = None,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> PagingResponse[Region]:
+        pass
+
+    dcim_all_regions = collect(dcim_regions)
+    dcim_all_regions_by_id = collect(dcim_regions, field="id")
+
+    @get("dcim/regions/{region_id}/")
+    def dcim_region(self, region_id: int) -> Region:
+        pass
+
+    @get("dcim/site-groups/")
+    def dcim_site_groups(
+        self,
+        id: list[int] | None = None,
+        name: list[str] | None = None,
+        slug: list[str] | None = None,
+        tag: list[str] | None = None,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> PagingResponse[SiteGroup]:
+        pass
+
+    dcim_all_site_groups = collect(dcim_site_groups)
+    dcim_all_site_groups_by_id = collect(dcim_site_groups, field="id")
+
+    @get("dcim/site-groups/{site_group_id}/")
+    def dcim_site_group(self, site_group_id: int) -> SiteGroup:
+        pass
+
+    @get("dcim/locations/")
+    def dcim_locations(
+        self,
+        id: list[int] | None = None,
+        name: list[str] | None = None,
+        slug: list[str] | None = None,
+        site: list[str] | None = None,
+        site_id: list[int] | None = None,
+        parent: list[str] | None = None,
+        parent_id: list[int] | None = None,
+        status: list[str] | None = None,
+        tenant: list[str] | None = None,
+        tag: list[str] | None = None,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> PagingResponse[Location]:
+        pass
+
+    dcim_all_locations = collect(dcim_locations)
+    dcim_all_locations_by_id = collect(dcim_locations, field="id")
+
+    @get("dcim/locations/{location_id}/")
+    def dcim_location(self, location_id: int) -> Location:
+        pass
+
+    @get("tenancy/tenant-groups/")
+    def tenancy_tenant_groups(
+        self,
+        id: list[int] | None = None,
+        name: list[str] | None = None,
+        slug: list[str] | None = None,
+        tag: list[str] | None = None,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> PagingResponse[TenantGroup]:
+        pass
+
+    tenancy_all_tenant_groups = collect(tenancy_tenant_groups)
+    tenancy_all_tenant_groups_by_id = collect(
+        tenancy_tenant_groups, field="id",
+    )
+
+    @get("tenancy/tenant-groups/{tenant_group_id}/")
+    def tenancy_tenant_group(self, tenant_group_id: int) -> TenantGroup:
         pass
 
     # ipam

--- a/src/annetbox/v41/models.py
+++ b/src/annetbox/v41/models.py
@@ -153,6 +153,46 @@ class Site(Entity):
 
 
 @dataclass
+class Region(EntityWithSlug):
+    description: str
+    custom_fields: dict[str, Any]
+    created: datetime
+    last_updated: datetime
+    parent: EntityWithSlug | None = None
+
+
+@dataclass
+class SiteGroup(EntityWithSlug):
+    description: str
+    custom_fields: dict[str, Any]
+    created: datetime
+    last_updated: datetime
+    parent: EntityWithSlug | None = None
+
+
+@dataclass
+class Location(EntityWithSlug):
+    site: Entity
+    status: Label
+    description: str
+    custom_fields: dict[str, Any]
+    created: datetime
+    last_updated: datetime
+    parent: EntityWithSlug | None = None
+    tenant: EntityWithSlug | None = None
+    facility: str = ""
+
+
+@dataclass
+class TenantGroup(EntityWithSlug):
+    description: str
+    custom_fields: dict[str, Any]
+    created: datetime
+    last_updated: datetime
+    parent: EntityWithSlug | None = None
+
+
+@dataclass
 class Device(Entity):
     url: str
     display: str  # renamed in 3.x from display_name

--- a/src/annetbox/v42/client_async.py
+++ b/src/annetbox/v42/client_async.py
@@ -19,9 +19,13 @@ from .models import (
     Interface,
     IpAddress,
     ItemToDelete,
+    Location,
     NewCable,
     Prefix,
+    Region,
     Site,
+    SiteGroup,
+    TenantGroup,
     TraceTuple,
     Vlan,
     Vrf,
@@ -224,6 +228,90 @@ class NetboxV42(BaseNetboxClient):
 
     @get("dcim/sites/{site_id}/")
     async def dcim_site(self, site_id: int) -> Site:
+        pass
+
+    @get("dcim/regions/")
+    async def dcim_regions(
+        self,
+        id: list[int] | None = None,
+        name: list[str] | None = None,
+        slug: list[str] | None = None,
+        tag: list[str] | None = None,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> PagingResponse[Region]:
+        pass
+
+    dcim_all_regions = collect(dcim_regions)
+    dcim_all_regions_by_id = collect(dcim_regions, field="id")
+
+    @get("dcim/regions/{region_id}/")
+    async def dcim_region(self, region_id: int) -> Region:
+        pass
+
+    @get("dcim/site-groups/")
+    async def dcim_site_groups(
+        self,
+        id: list[int] | None = None,
+        name: list[str] | None = None,
+        slug: list[str] | None = None,
+        tag: list[str] | None = None,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> PagingResponse[SiteGroup]:
+        pass
+
+    dcim_all_site_groups = collect(dcim_site_groups)
+    dcim_all_site_groups_by_id = collect(dcim_site_groups, field="id")
+
+    @get("dcim/site-groups/{site_group_id}/")
+    async def dcim_site_group(self, site_group_id: int) -> SiteGroup:
+        pass
+
+    @get("dcim/locations/")
+    async def dcim_locations(
+        self,
+        id: list[int] | None = None,
+        name: list[str] | None = None,
+        slug: list[str] | None = None,
+        site: list[str] | None = None,
+        site_id: list[int] | None = None,
+        parent: list[str] | None = None,
+        parent_id: list[int] | None = None,
+        status: list[str] | None = None,
+        tenant: list[str] | None = None,
+        tag: list[str] | None = None,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> PagingResponse[Location]:
+        pass
+
+    dcim_all_locations = collect(dcim_locations)
+    dcim_all_locations_by_id = collect(dcim_locations, field="id")
+
+    @get("dcim/locations/{location_id}/")
+    async def dcim_location(self, location_id: int) -> Location:
+        pass
+
+    @get("tenancy/tenant-groups/")
+    async def tenancy_tenant_groups(
+        self,
+        id: list[int] | None = None,
+        name: list[str] | None = None,
+        slug: list[str] | None = None,
+        tag: list[str] | None = None,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> PagingResponse[TenantGroup]:
+        pass
+
+    tenancy_all_tenant_groups = collect(tenancy_tenant_groups)
+    tenancy_all_tenant_groups_by_id = collect(
+        tenancy_tenant_groups, field="id",
+    )
+
+    @get("tenancy/tenant-groups/{tenant_group_id}/")
+    async def tenancy_tenant_group(self, tenant_group_id: int) -> TenantGroup:
         pass
 
     # ipam

--- a/src/annetbox/v42/client_sync.py
+++ b/src/annetbox/v42/client_sync.py
@@ -19,9 +19,13 @@ from .models import (
     Interface,
     IpAddress,
     ItemToDelete,
+    Location,
     NewCable,
     Prefix,
+    Region,
     Site,
+    SiteGroup,
+    TenantGroup,
     TraceTuple,
     Vlan,
     Vrf,
@@ -224,6 +228,90 @@ class NetboxV42(BaseNetboxClient):
 
     @get("dcim/sites/{site_id}/")
     def dcim_site(self, site_id: int) -> Site:
+        pass
+
+    @get("dcim/regions/")
+    def dcim_regions(
+        self,
+        id: list[int] | None = None,
+        name: list[str] | None = None,
+        slug: list[str] | None = None,
+        tag: list[str] | None = None,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> PagingResponse[Region]:
+        pass
+
+    dcim_all_regions = collect(dcim_regions)
+    dcim_all_regions_by_id = collect(dcim_regions, field="id")
+
+    @get("dcim/regions/{region_id}/")
+    def dcim_region(self, region_id: int) -> Region:
+        pass
+
+    @get("dcim/site-groups/")
+    def dcim_site_groups(
+        self,
+        id: list[int] | None = None,
+        name: list[str] | None = None,
+        slug: list[str] | None = None,
+        tag: list[str] | None = None,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> PagingResponse[SiteGroup]:
+        pass
+
+    dcim_all_site_groups = collect(dcim_site_groups)
+    dcim_all_site_groups_by_id = collect(dcim_site_groups, field="id")
+
+    @get("dcim/site-groups/{site_group_id}/")
+    def dcim_site_group(self, site_group_id: int) -> SiteGroup:
+        pass
+
+    @get("dcim/locations/")
+    def dcim_locations(
+        self,
+        id: list[int] | None = None,
+        name: list[str] | None = None,
+        slug: list[str] | None = None,
+        site: list[str] | None = None,
+        site_id: list[int] | None = None,
+        parent: list[str] | None = None,
+        parent_id: list[int] | None = None,
+        status: list[str] | None = None,
+        tenant: list[str] | None = None,
+        tag: list[str] | None = None,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> PagingResponse[Location]:
+        pass
+
+    dcim_all_locations = collect(dcim_locations)
+    dcim_all_locations_by_id = collect(dcim_locations, field="id")
+
+    @get("dcim/locations/{location_id}/")
+    def dcim_location(self, location_id: int) -> Location:
+        pass
+
+    @get("tenancy/tenant-groups/")
+    def tenancy_tenant_groups(
+        self,
+        id: list[int] | None = None,
+        name: list[str] | None = None,
+        slug: list[str] | None = None,
+        tag: list[str] | None = None,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> PagingResponse[TenantGroup]:
+        pass
+
+    tenancy_all_tenant_groups = collect(tenancy_tenant_groups)
+    tenancy_all_tenant_groups_by_id = collect(
+        tenancy_tenant_groups, field="id",
+    )
+
+    @get("tenancy/tenant-groups/{tenant_group_id}/")
+    def tenancy_tenant_group(self, tenant_group_id: int) -> TenantGroup:
         pass
 
     # ipam

--- a/src/annetbox/v42/models.py
+++ b/src/annetbox/v42/models.py
@@ -152,6 +152,46 @@ class Site(Entity):
 
 
 @dataclass
+class Region(EntityWithSlug):
+    description: str
+    custom_fields: dict[str, Any]
+    created: datetime
+    last_updated: datetime
+    parent: EntityWithSlug | None = None
+
+
+@dataclass
+class SiteGroup(EntityWithSlug):
+    description: str
+    custom_fields: dict[str, Any]
+    created: datetime
+    last_updated: datetime
+    parent: EntityWithSlug | None = None
+
+
+@dataclass
+class Location(EntityWithSlug):
+    site: Entity
+    status: Label
+    description: str
+    custom_fields: dict[str, Any]
+    created: datetime
+    last_updated: datetime
+    parent: EntityWithSlug | None = None
+    tenant: EntityWithSlug | None = None
+    facility: str = ""
+
+
+@dataclass
+class TenantGroup(EntityWithSlug):
+    description: str
+    custom_fields: dict[str, Any]
+    created: datetime
+    last_updated: datetime
+    parent: EntityWithSlug | None = None
+
+
+@dataclass
 class Device(Entity):
     url: str
     display: str  # renamed in 3.x from display_name

--- a/tests/integration/definitions.yaml
+++ b/tests/integration/definitions.yaml
@@ -155,6 +155,66 @@ tests:
         args: {type: ["dark-fiber"], limit: 1}
         extract: results[0].id
 
+  - id: dcim_regions_01
+    method: dcim_regions
+    versions: ["v37", "v41", "v42"]
+    args:
+      limit: 5
+
+  - id: dcim_region_01
+    method: dcim_region
+    versions: ["v37", "v41", "v42"]
+    args:
+      region_id: !from_call
+        call: dcim_regions
+        args: {limit: 5}
+        extract: results[0].id
+
+  - id: dcim_site_groups_01
+    method: dcim_site_groups
+    versions: ["v37", "v41", "v42"]
+    args:
+      limit: 5
+
+  - id: dcim_site_group_01
+    method: dcim_site_group
+    versions: ["v37", "v41", "v42"]
+    args:
+      site_group_id: !from_call
+        call: dcim_site_groups
+        args: {limit: 5}
+        extract: results[0].id
+
+  - id: dcim_locations_01
+    method: dcim_locations
+    versions: ["v37", "v41", "v42"]
+    args:
+      limit: 5
+
+  - id: dcim_location_01
+    method: dcim_location
+    versions: ["v37", "v41", "v42"]
+    args:
+      location_id: !from_call
+        call: dcim_locations
+        args: {limit: 5}
+        extract: results[0].id
+
+  - id: tenancy_tenant_groups_01
+    method: tenancy_tenant_groups
+    versions: ["v37", "v41", "v42"]
+    args:
+      limit: 5
+
+  - id: tenancy_tenant_group_01
+    method: tenancy_tenant_group
+    versions: ["v37", "v41", "v42"]
+    args:
+      tenant_group_id: !from_call
+        call: tenancy_tenant_groups
+        args: {limit: 5}
+        extract: results[0].id
+
   ####
   #### Versions: v42
   ####

--- a/tests/integration/fixtures/v37/circuit_dark_fiber_01/cassette.yaml
+++ b/tests/integration/fixtures/v37/circuit_dark_fiber_01/cassette.yaml
@@ -8,8 +8,6 @@ interactions:
       - gzip, deflate, zstd
       Connection:
       - keep-alive
-      User-Agent:
-      - python-requests/2.33.1
     method: GET
     uri: http://localhost:8037/api/circuits/circuits/?limit=1&offset=0&type=dark-fiber
   response:
@@ -52,8 +50,6 @@ interactions:
       - gzip, deflate, zstd
       Connection:
       - keep-alive
-      User-Agent:
-      - python-requests/2.33.1
     method: GET
     uri: http://localhost:8037/api/circuits/circuits/30/
   response:

--- a/tests/integration/fixtures/v37/circuit_internet_01/cassette.yaml
+++ b/tests/integration/fixtures/v37/circuit_internet_01/cassette.yaml
@@ -8,8 +8,6 @@ interactions:
       - gzip, deflate, zstd
       Connection:
       - keep-alive
-      User-Agent:
-      - python-requests/2.33.1
     method: GET
     uri: http://localhost:8037/api/circuits/circuits/?limit=1&offset=0&type=internet
   response:
@@ -49,8 +47,6 @@ interactions:
       - gzip, deflate, zstd
       Connection:
       - keep-alive
-      User-Agent:
-      - python-requests/2.33.1
     method: GET
     uri: http://localhost:8037/api/circuits/circuits/19/
   response:

--- a/tests/integration/fixtures/v37/circuit_mpls_01/cassette.yaml
+++ b/tests/integration/fixtures/v37/circuit_mpls_01/cassette.yaml
@@ -8,8 +8,6 @@ interactions:
       - gzip, deflate, zstd
       Connection:
       - keep-alive
-      User-Agent:
-      - python-requests/2.33.1
     method: GET
     uri: http://localhost:8037/api/circuits/circuits/?limit=1&offset=0&type=mpls
   response:
@@ -51,8 +49,6 @@ interactions:
       - gzip, deflate, zstd
       Connection:
       - keep-alive
-      User-Agent:
-      - python-requests/2.33.1
     method: GET
     uri: http://localhost:8037/api/circuits/circuits/14/
   response:

--- a/tests/integration/fixtures/v37/circuits_dark_fiber_01/cassette.yaml
+++ b/tests/integration/fixtures/v37/circuits_dark_fiber_01/cassette.yaml
@@ -8,8 +8,6 @@ interactions:
       - gzip, deflate, zstd
       Connection:
       - keep-alive
-      User-Agent:
-      - python-requests/2.33.1
     method: GET
     uri: http://localhost:8037/api/circuits/circuits/?limit=20&offset=0&type=dark-fiber
   response:

--- a/tests/integration/fixtures/v37/circuits_internet_01/cassette.yaml
+++ b/tests/integration/fixtures/v37/circuits_internet_01/cassette.yaml
@@ -8,8 +8,6 @@ interactions:
       - gzip, deflate, zstd
       Connection:
       - keep-alive
-      User-Agent:
-      - python-requests/2.33.1
     method: GET
     uri: http://localhost:8037/api/circuits/circuits/?limit=20&offset=0&type=internet
   response:

--- a/tests/integration/fixtures/v37/circuits_mpls_01/cassette.yaml
+++ b/tests/integration/fixtures/v37/circuits_mpls_01/cassette.yaml
@@ -8,8 +8,6 @@ interactions:
       - gzip, deflate, zstd
       Connection:
       - keep-alive
-      User-Agent:
-      - python-requests/2.33.1
     method: GET
     uri: http://localhost:8037/api/circuits/circuits/?limit=20&offset=0&type=mpls
   response:

--- a/tests/integration/fixtures/v37/dcim_all_devices_01/cassette.yaml
+++ b/tests/integration/fixtures/v37/dcim_all_devices_01/cassette.yaml
@@ -8,8 +8,6 @@ interactions:
       - gzip, deflate, zstd
       Connection:
       - keep-alive
-      User-Agent:
-      - python-requests/2.33.1
     method: GET
     uri: http://localhost:8037/api/dcim/devices/?limit=30&offset=0
   response:

--- a/tests/integration/fixtures/v37/dcim_all_interfaces_01/cassette.yaml
+++ b/tests/integration/fixtures/v37/dcim_all_interfaces_01/cassette.yaml
@@ -8,8 +8,6 @@ interactions:
       - gzip, deflate, zstd
       Connection:
       - keep-alive
-      User-Agent:
-      - python-requests/2.33.1
     method: GET
     uri: http://localhost:8037/api/dcim/interfaces/?device_id=1&device_id=2&device_id=3&device_id=4&device_id=5&device_id=6&device_id=7&device_id=8&device_id=9&device_id=10&limit=100&offset=0
   response:
@@ -163,8 +161,6 @@ interactions:
       - gzip, deflate, zstd
       Connection:
       - keep-alive
-      User-Agent:
-      - python-requests/2.33.1
     method: GET
     uri: http://localhost:8037/api/dcim/interfaces/?device_id=1&device_id=2&device_id=3&device_id=4&device_id=5&device_id=6&device_id=7&device_id=8&device_id=9&device_id=10&limit=100&offset=100
   response:
@@ -244,8 +240,6 @@ interactions:
       - gzip, deflate, zstd
       Connection:
       - keep-alive
-      User-Agent:
-      - python-requests/2.33.1
     method: GET
     uri: http://localhost:8037/api/dcim/interfaces/?device_id=11&device_id=12&device_id=13&limit=100&offset=0
   response:

--- a/tests/integration/fixtures/v37/dcim_cables_01/cassette.yaml
+++ b/tests/integration/fixtures/v37/dcim_cables_01/cassette.yaml
@@ -8,8 +8,6 @@ interactions:
       - gzip, deflate, zstd
       Connection:
       - keep-alive
-      User-Agent:
-      - python-requests/2.33.1
     method: GET
     uri: http://localhost:8037/api/dcim/cables/?limit=5&offset=0
   response:

--- a/tests/integration/fixtures/v37/dcim_console_port_01/cassette.yaml
+++ b/tests/integration/fixtures/v37/dcim_console_port_01/cassette.yaml
@@ -8,8 +8,6 @@ interactions:
       - gzip, deflate, zstd
       Connection:
       - keep-alive
-      User-Agent:
-      - python-requests/2.33.1
     method: GET
     uri: http://localhost:8037/api/dcim/console-ports/?limit=5&offset=0
   response:
@@ -54,8 +52,6 @@ interactions:
       - gzip, deflate, zstd
       Connection:
       - keep-alive
-      User-Agent:
-      - python-requests/2.33.1
     method: GET
     uri: http://localhost:8037/api/dcim/console-ports/1/
   response:

--- a/tests/integration/fixtures/v37/dcim_console_ports_01/cassette.yaml
+++ b/tests/integration/fixtures/v37/dcim_console_ports_01/cassette.yaml
@@ -8,8 +8,6 @@ interactions:
       - gzip, deflate, zstd
       Connection:
       - keep-alive
-      User-Agent:
-      - python-requests/2.33.1
     method: GET
     uri: http://localhost:8037/api/dcim/console-ports/?limit=5&offset=0
   response:

--- a/tests/integration/fixtures/v37/dcim_device_01/cassette.yaml
+++ b/tests/integration/fixtures/v37/dcim_device_01/cassette.yaml
@@ -8,8 +8,6 @@ interactions:
       - gzip, deflate, zstd
       Connection:
       - keep-alive
-      User-Agent:
-      - python-requests/2.33.1
     method: GET
     uri: http://localhost:8037/api/dcim/devices/?limit=10&offset=0
   response:
@@ -95,8 +93,6 @@ interactions:
       - gzip, deflate, zstd
       Connection:
       - keep-alive
-      User-Agent:
-      - python-requests/2.33.1
     method: GET
     uri: http://localhost:8037/api/dcim/devices/88/
   response:

--- a/tests/integration/fixtures/v37/dcim_devices_01/cassette.yaml
+++ b/tests/integration/fixtures/v37/dcim_devices_01/cassette.yaml
@@ -8,8 +8,6 @@ interactions:
       - gzip, deflate, zstd
       Connection:
       - keep-alive
-      User-Agent:
-      - python-requests/2.33.1
     method: GET
     uri: http://localhost:8037/api/dcim/devices/?limit=10&offset=0
   response:

--- a/tests/integration/fixtures/v37/dcim_interface_trace_01/cassette.yaml
+++ b/tests/integration/fixtures/v37/dcim_interface_trace_01/cassette.yaml
@@ -8,8 +8,6 @@ interactions:
       - gzip, deflate, zstd
       Connection:
       - keep-alive
-      User-Agent:
-      - python-requests/2.33.1
     method: GET
     uri: http://localhost:8037/api/dcim/interfaces/28/trace/
   response:

--- a/tests/integration/fixtures/v37/dcim_interface_trace_02/cassette.yaml
+++ b/tests/integration/fixtures/v37/dcim_interface_trace_02/cassette.yaml
@@ -8,8 +8,6 @@ interactions:
       - gzip, deflate, zstd
       Connection:
       - keep-alive
-      User-Agent:
-      - python-requests/2.33.1
     method: GET
     uri: http://localhost:8037/api/dcim/interfaces/157/trace/
   response:

--- a/tests/integration/fixtures/v37/dcim_interface_trace_03/cassette.yaml
+++ b/tests/integration/fixtures/v37/dcim_interface_trace_03/cassette.yaml
@@ -8,8 +8,6 @@ interactions:
       - gzip, deflate, zstd
       Connection:
       - keep-alive
-      User-Agent:
-      - python-requests/2.33.1
     method: GET
     uri: http://localhost:8037/api/dcim/interfaces/969/trace/
   response:

--- a/tests/integration/fixtures/v37/dcim_location_01/cassette.yaml
+++ b/tests/integration/fixtures/v37/dcim_location_01/cassette.yaml
@@ -1,0 +1,79 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+    method: GET
+    uri: http://localhost:8037/api/dcim/locations/?limit=5&offset=0
+  response:
+    body:
+      string: '{"count":4,"next":null,"previous":null,"results":[{"id":1,"url":"http://localhost:8037/api/dcim/locations/1/","display":"Row
+        1","name":"Row 1","slug":"row-1","site":{"id":21,"url":"http://localhost:8037/api/dcim/sites/21/","display":"MDF","name":"MDF","slug":"ncsu-065"},"parent":null,"status":{"value":"active","label":"Active"},"tenant":null,"description":"","tags":[],"custom_fields":{},"created":"2021-04-02T00:00:00Z","last_updated":"2021-04-02T16:57:17.398000Z","rack_count":8,"device_count":10,"_depth":0},{"id":2,"url":"http://localhost:8037/api/dcim/locations/2/","display":"Row
+        2","name":"Row 2","slug":"row-2","site":{"id":21,"url":"http://localhost:8037/api/dcim/sites/21/","display":"MDF","name":"MDF","slug":"ncsu-065"},"parent":null,"status":{"value":"active","label":"Active"},"tenant":null,"description":"","tags":[],"custom_fields":{},"created":"2021-04-02T00:00:00Z","last_updated":"2021-04-02T16:57:24.629000Z","rack_count":8,"device_count":1,"_depth":0},{"id":3,"url":"http://localhost:8037/api/dcim/locations/3/","display":"Row
+        3","name":"Row 3","slug":"row-3","site":{"id":21,"url":"http://localhost:8037/api/dcim/sites/21/","display":"MDF","name":"MDF","slug":"ncsu-065"},"parent":null,"status":{"value":"active","label":"Active"},"tenant":null,"description":"","tags":[],"custom_fields":{},"created":"2021-04-02T00:00:00Z","last_updated":"2021-04-02T16:57:31.713000Z","rack_count":8,"device_count":0,"_depth":0},{"id":4,"url":"http://localhost:8037/api/dcim/locations/4/","display":"Row
+        4","name":"Row 4","slug":"row-4","site":{"id":21,"url":"http://localhost:8037/api/dcim/sites/21/","display":"MDF","name":"MDF","slug":"ncsu-065"},"parent":null,"status":{"value":"active","label":"Active"},"tenant":null,"description":"","tags":[],"custom_fields":{},"created":"2021-04-02T00:00:00Z","last_updated":"2021-04-02T16:57:37.732000Z","rack_count":0,"device_count":0,"_depth":0}]}'
+    headers:
+      Allow:
+      - GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS
+      Content-Length:
+      - '1900'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - Unit/1.31.1
+      Vary:
+      - HX-Request, Cookie, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+    method: GET
+    uri: http://localhost:8037/api/dcim/locations/1/
+  response:
+    body:
+      string: '{"id":1,"url":"http://localhost:8037/api/dcim/locations/1/","display":"Row
+        1","name":"Row 1","slug":"row-1","site":{"id":21,"url":"http://localhost:8037/api/dcim/sites/21/","display":"MDF","name":"MDF","slug":"ncsu-065"},"parent":null,"status":{"value":"active","label":"Active"},"tenant":null,"description":"","tags":[],"custom_fields":{},"created":"2021-04-02T00:00:00Z","last_updated":"2021-04-02T16:57:17.398000Z","rack_count":8,"device_count":10,"_depth":0}'
+    headers:
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      Content-Length:
+      - '462'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - Unit/1.31.1
+      Vary:
+      - HX-Request, Cookie, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/integration/fixtures/v37/dcim_location_01/expected.yaml
+++ b/tests/integration/fixtures/v37/dcim_location_01/expected.yaml
@@ -1,0 +1,39 @@
+# AUTO-GENERATED - DO NOT EDIT
+# This file is generated from definitions.yaml
+# To regenerate: python -m tests.integration.generate_fixtures
+
+definition:
+  id: dcim_location_01
+  method: dcim_location
+  args:
+    location_id:
+      call: dcim_locations
+      args:
+        limit: 5
+      extract: results[0].id
+call:
+  client_call: dcim_location
+  client_call_args: []
+  client_call_kwargs:
+    location_id: 1
+output: !!python/object:annetbox.v37.models.Location
+  id: 1
+  name: Row 1
+  display: Row 1
+  url: http://localhost:8037/api/dcim/locations/1/
+  slug: row-1
+  site: !!python/object:annetbox.v37.models.Entity
+    id: 21
+    name: MDF
+    display: MDF
+    url: http://localhost:8037/api/dcim/sites/21/
+  status: !!python/object:annetbox.v37.models.Label
+    value: active
+    label: Active
+  description: ''
+  custom_fields: {}
+  created: 2021-04-02 00:00:00+00:00
+  last_updated: 2021-04-02 16:57:17.398000+00:00
+  parent: null
+  tenant: null
+  facility: ''

--- a/tests/integration/fixtures/v37/dcim_locations_01/cassette.yaml
+++ b/tests/integration/fixtures/v37/dcim_locations_01/cassette.yaml
@@ -1,0 +1,42 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+    method: GET
+    uri: http://localhost:8037/api/dcim/locations/?limit=5&offset=0
+  response:
+    body:
+      string: '{"count":4,"next":null,"previous":null,"results":[{"id":1,"url":"http://localhost:8037/api/dcim/locations/1/","display":"Row
+        1","name":"Row 1","slug":"row-1","site":{"id":21,"url":"http://localhost:8037/api/dcim/sites/21/","display":"MDF","name":"MDF","slug":"ncsu-065"},"parent":null,"status":{"value":"active","label":"Active"},"tenant":null,"description":"","tags":[],"custom_fields":{},"created":"2021-04-02T00:00:00Z","last_updated":"2021-04-02T16:57:17.398000Z","rack_count":8,"device_count":10,"_depth":0},{"id":2,"url":"http://localhost:8037/api/dcim/locations/2/","display":"Row
+        2","name":"Row 2","slug":"row-2","site":{"id":21,"url":"http://localhost:8037/api/dcim/sites/21/","display":"MDF","name":"MDF","slug":"ncsu-065"},"parent":null,"status":{"value":"active","label":"Active"},"tenant":null,"description":"","tags":[],"custom_fields":{},"created":"2021-04-02T00:00:00Z","last_updated":"2021-04-02T16:57:24.629000Z","rack_count":8,"device_count":1,"_depth":0},{"id":3,"url":"http://localhost:8037/api/dcim/locations/3/","display":"Row
+        3","name":"Row 3","slug":"row-3","site":{"id":21,"url":"http://localhost:8037/api/dcim/sites/21/","display":"MDF","name":"MDF","slug":"ncsu-065"},"parent":null,"status":{"value":"active","label":"Active"},"tenant":null,"description":"","tags":[],"custom_fields":{},"created":"2021-04-02T00:00:00Z","last_updated":"2021-04-02T16:57:31.713000Z","rack_count":8,"device_count":0,"_depth":0},{"id":4,"url":"http://localhost:8037/api/dcim/locations/4/","display":"Row
+        4","name":"Row 4","slug":"row-4","site":{"id":21,"url":"http://localhost:8037/api/dcim/sites/21/","display":"MDF","name":"MDF","slug":"ncsu-065"},"parent":null,"status":{"value":"active","label":"Active"},"tenant":null,"description":"","tags":[],"custom_fields":{},"created":"2021-04-02T00:00:00Z","last_updated":"2021-04-02T16:57:37.732000Z","rack_count":0,"device_count":0,"_depth":0}]}'
+    headers:
+      Allow:
+      - GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS
+      Content-Length:
+      - '1900'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - Unit/1.31.1
+      Vary:
+      - HX-Request, Cookie, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/integration/fixtures/v37/dcim_locations_01/expected.yaml
+++ b/tests/integration/fixtures/v37/dcim_locations_01/expected.yaml
@@ -1,0 +1,103 @@
+# AUTO-GENERATED - DO NOT EDIT
+# This file is generated from definitions.yaml
+# To regenerate: python -m tests.integration.generate_fixtures
+
+definition:
+  id: dcim_locations_01
+  method: dcim_locations
+  args:
+    limit: 5
+call:
+  client_call: dcim_locations
+  client_call_args: []
+  client_call_kwargs:
+    limit: 5
+output: !!python/object:annetbox.base.models.PagingResponse
+  next: null
+  previous: null
+  count: 4
+  results:
+  - !!python/object:annetbox.v37.models.Location
+    id: 1
+    name: Row 1
+    display: Row 1
+    url: http://localhost:8037/api/dcim/locations/1/
+    slug: row-1
+    site: !!python/object:annetbox.v37.models.Entity
+      id: 21
+      name: MDF
+      display: MDF
+      url: http://localhost:8037/api/dcim/sites/21/
+    status: !!python/object:annetbox.v37.models.Label
+      value: active
+      label: Active
+    description: ''
+    custom_fields: {}
+    created: 2021-04-02 00:00:00+00:00
+    last_updated: 2021-04-02 16:57:17.398000+00:00
+    parent: null
+    tenant: null
+    facility: ''
+  - !!python/object:annetbox.v37.models.Location
+    id: 2
+    name: Row 2
+    display: Row 2
+    url: http://localhost:8037/api/dcim/locations/2/
+    slug: row-2
+    site: !!python/object:annetbox.v37.models.Entity
+      id: 21
+      name: MDF
+      display: MDF
+      url: http://localhost:8037/api/dcim/sites/21/
+    status: !!python/object:annetbox.v37.models.Label
+      value: active
+      label: Active
+    description: ''
+    custom_fields: {}
+    created: 2021-04-02 00:00:00+00:00
+    last_updated: 2021-04-02 16:57:24.629000+00:00
+    parent: null
+    tenant: null
+    facility: ''
+  - !!python/object:annetbox.v37.models.Location
+    id: 3
+    name: Row 3
+    display: Row 3
+    url: http://localhost:8037/api/dcim/locations/3/
+    slug: row-3
+    site: !!python/object:annetbox.v37.models.Entity
+      id: 21
+      name: MDF
+      display: MDF
+      url: http://localhost:8037/api/dcim/sites/21/
+    status: !!python/object:annetbox.v37.models.Label
+      value: active
+      label: Active
+    description: ''
+    custom_fields: {}
+    created: 2021-04-02 00:00:00+00:00
+    last_updated: 2021-04-02 16:57:31.713000+00:00
+    parent: null
+    tenant: null
+    facility: ''
+  - !!python/object:annetbox.v37.models.Location
+    id: 4
+    name: Row 4
+    display: Row 4
+    url: http://localhost:8037/api/dcim/locations/4/
+    slug: row-4
+    site: !!python/object:annetbox.v37.models.Entity
+      id: 21
+      name: MDF
+      display: MDF
+      url: http://localhost:8037/api/dcim/sites/21/
+    status: !!python/object:annetbox.v37.models.Label
+      value: active
+      label: Active
+    description: ''
+    custom_fields: {}
+    created: 2021-04-02 00:00:00+00:00
+    last_updated: 2021-04-02 16:57:37.732000+00:00
+    parent: null
+    tenant: null
+    facility: ''

--- a/tests/integration/fixtures/v37/dcim_region_01/cassette.yaml
+++ b/tests/integration/fixtures/v37/dcim_region_01/cassette.yaml
@@ -1,0 +1,74 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+    method: GET
+    uri: http://localhost:8037/api/dcim/regions/?limit=5&offset=0
+  response:
+    body:
+      string: '{"count":67,"next":"http://localhost:8037/api/dcim/regions/?limit=5&offset=5","previous":null,"results":[{"id":4,"url":"http://localhost:8037/api/dcim/regions/4/","display":"Africa","name":"Africa","slug":"africa","parent":null,"description":"","tags":[],"custom_fields":{},"created":"2020-12-18T00:00:00Z","last_updated":"2020-12-18T02:10:30.332000Z","site_count":0,"_depth":0},{"id":5,"url":"http://localhost:8037/api/dcim/regions/5/","display":"Asia","name":"Asia","slug":"asia","parent":null,"description":"","tags":[],"custom_fields":{},"created":"2020-12-18T00:00:00Z","last_updated":"2020-12-18T02:10:30.367000Z","site_count":0,"_depth":0},{"id":15,"url":"http://localhost:8037/api/dcim/regions/15/","display":"China","name":"China","slug":"cn","parent":{"id":5,"url":"http://localhost:8037/api/dcim/regions/5/","display":"Asia","name":"Asia","slug":"asia","_depth":0},"description":"","tags":[],"custom_fields":{},"created":"2020-12-18T00:00:00Z","last_updated":"2020-12-18T02:17:11.368000Z","site_count":0,"_depth":1},{"id":16,"url":"http://localhost:8037/api/dcim/regions/16/","display":"India","name":"India","slug":"in","parent":{"id":5,"url":"http://localhost:8037/api/dcim/regions/5/","display":"Asia","name":"Asia","slug":"asia","_depth":0},"description":"","tags":[],"custom_fields":{},"created":"2020-12-18T00:00:00Z","last_updated":"2020-12-18T02:17:11.423000Z","site_count":0,"_depth":1},{"id":14,"url":"http://localhost:8037/api/dcim/regions/14/","display":"Singapore","name":"Singapore","slug":"sg","parent":{"id":5,"url":"http://localhost:8037/api/dcim/regions/5/","display":"Asia","name":"Asia","slug":"asia","_depth":0},"description":"","tags":[],"custom_fields":{},"created":"2020-12-18T00:00:00Z","last_updated":"2020-12-18T02:17:11.318000Z","site_count":0,"_depth":1}]}'
+    headers:
+      Allow:
+      - GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS
+      Content-Length:
+      - '1796'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - Unit/1.31.1
+      Vary:
+      - HX-Request, Cookie, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+    method: GET
+    uri: http://localhost:8037/api/dcim/regions/4/
+  response:
+    body:
+      string: '{"id":4,"url":"http://localhost:8037/api/dcim/regions/4/","display":"Africa","name":"Africa","slug":"africa","parent":null,"description":"","tags":[],"custom_fields":{},"created":"2020-12-18T00:00:00Z","last_updated":"2020-12-18T02:10:30.332000Z","site_count":0,"_depth":0}'
+    headers:
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      Content-Length:
+      - '273'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - Unit/1.31.1
+      Vary:
+      - HX-Request, Cookie, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/integration/fixtures/v37/dcim_region_01/expected.yaml
+++ b/tests/integration/fixtures/v37/dcim_region_01/expected.yaml
@@ -1,0 +1,29 @@
+# AUTO-GENERATED - DO NOT EDIT
+# This file is generated from definitions.yaml
+# To regenerate: python -m tests.integration.generate_fixtures
+
+definition:
+  id: dcim_region_01
+  method: dcim_region
+  args:
+    region_id:
+      call: dcim_regions
+      args:
+        limit: 5
+      extract: results[0].id
+call:
+  client_call: dcim_region
+  client_call_args: []
+  client_call_kwargs:
+    region_id: 4
+output: !!python/object:annetbox.v37.models.Region
+  id: 4
+  name: Africa
+  display: Africa
+  url: http://localhost:8037/api/dcim/regions/4/
+  slug: africa
+  description: ''
+  custom_fields: {}
+  created: 2020-12-18 00:00:00+00:00
+  last_updated: 2020-12-18 02:10:30.332000+00:00
+  parent: null

--- a/tests/integration/fixtures/v37/dcim_regions_01/cassette.yaml
+++ b/tests/integration/fixtures/v37/dcim_regions_01/cassette.yaml
@@ -1,0 +1,38 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+    method: GET
+    uri: http://localhost:8037/api/dcim/regions/?limit=5&offset=0
+  response:
+    body:
+      string: '{"count":67,"next":"http://localhost:8037/api/dcim/regions/?limit=5&offset=5","previous":null,"results":[{"id":4,"url":"http://localhost:8037/api/dcim/regions/4/","display":"Africa","name":"Africa","slug":"africa","parent":null,"description":"","tags":[],"custom_fields":{},"created":"2020-12-18T00:00:00Z","last_updated":"2020-12-18T02:10:30.332000Z","site_count":0,"_depth":0},{"id":5,"url":"http://localhost:8037/api/dcim/regions/5/","display":"Asia","name":"Asia","slug":"asia","parent":null,"description":"","tags":[],"custom_fields":{},"created":"2020-12-18T00:00:00Z","last_updated":"2020-12-18T02:10:30.367000Z","site_count":0,"_depth":0},{"id":15,"url":"http://localhost:8037/api/dcim/regions/15/","display":"China","name":"China","slug":"cn","parent":{"id":5,"url":"http://localhost:8037/api/dcim/regions/5/","display":"Asia","name":"Asia","slug":"asia","_depth":0},"description":"","tags":[],"custom_fields":{},"created":"2020-12-18T00:00:00Z","last_updated":"2020-12-18T02:17:11.368000Z","site_count":0,"_depth":1},{"id":16,"url":"http://localhost:8037/api/dcim/regions/16/","display":"India","name":"India","slug":"in","parent":{"id":5,"url":"http://localhost:8037/api/dcim/regions/5/","display":"Asia","name":"Asia","slug":"asia","_depth":0},"description":"","tags":[],"custom_fields":{},"created":"2020-12-18T00:00:00Z","last_updated":"2020-12-18T02:17:11.423000Z","site_count":0,"_depth":1},{"id":14,"url":"http://localhost:8037/api/dcim/regions/14/","display":"Singapore","name":"Singapore","slug":"sg","parent":{"id":5,"url":"http://localhost:8037/api/dcim/regions/5/","display":"Asia","name":"Asia","slug":"asia","_depth":0},"description":"","tags":[],"custom_fields":{},"created":"2020-12-18T00:00:00Z","last_updated":"2020-12-18T02:17:11.318000Z","site_count":0,"_depth":1}]}'
+    headers:
+      Allow:
+      - GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS
+      Content-Length:
+      - '1796'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - Unit/1.31.1
+      Vary:
+      - HX-Request, Cookie, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/integration/fixtures/v37/dcim_regions_01/expected.yaml
+++ b/tests/integration/fixtures/v37/dcim_regions_01/expected.yaml
@@ -1,0 +1,89 @@
+# AUTO-GENERATED - DO NOT EDIT
+# This file is generated from definitions.yaml
+# To regenerate: python -m tests.integration.generate_fixtures
+
+definition:
+  id: dcim_regions_01
+  method: dcim_regions
+  args:
+    limit: 5
+call:
+  client_call: dcim_regions
+  client_call_args: []
+  client_call_kwargs:
+    limit: 5
+output: !!python/object:annetbox.base.models.PagingResponse
+  next: http://localhost:8037/api/dcim/regions/?limit=5&offset=5
+  previous: null
+  count: 67
+  results:
+  - !!python/object:annetbox.v37.models.Region
+    id: 4
+    name: Africa
+    display: Africa
+    url: http://localhost:8037/api/dcim/regions/4/
+    slug: africa
+    description: ''
+    custom_fields: {}
+    created: 2020-12-18 00:00:00+00:00
+    last_updated: 2020-12-18 02:10:30.332000+00:00
+    parent: null
+  - !!python/object:annetbox.v37.models.Region
+    id: 5
+    name: Asia
+    display: Asia
+    url: http://localhost:8037/api/dcim/regions/5/
+    slug: asia
+    description: ''
+    custom_fields: {}
+    created: 2020-12-18 00:00:00+00:00
+    last_updated: 2020-12-18 02:10:30.367000+00:00
+    parent: null
+  - !!python/object:annetbox.v37.models.Region
+    id: 15
+    name: China
+    display: China
+    url: http://localhost:8037/api/dcim/regions/15/
+    slug: cn
+    description: ''
+    custom_fields: {}
+    created: 2020-12-18 00:00:00+00:00
+    last_updated: 2020-12-18 02:17:11.368000+00:00
+    parent: !!python/object:annetbox.v37.models.EntityWithSlug
+      id: 5
+      name: Asia
+      display: Asia
+      url: http://localhost:8037/api/dcim/regions/5/
+      slug: asia
+  - !!python/object:annetbox.v37.models.Region
+    id: 16
+    name: India
+    display: India
+    url: http://localhost:8037/api/dcim/regions/16/
+    slug: in
+    description: ''
+    custom_fields: {}
+    created: 2020-12-18 00:00:00+00:00
+    last_updated: 2020-12-18 02:17:11.423000+00:00
+    parent: !!python/object:annetbox.v37.models.EntityWithSlug
+      id: 5
+      name: Asia
+      display: Asia
+      url: http://localhost:8037/api/dcim/regions/5/
+      slug: asia
+  - !!python/object:annetbox.v37.models.Region
+    id: 14
+    name: Singapore
+    display: Singapore
+    url: http://localhost:8037/api/dcim/regions/14/
+    slug: sg
+    description: ''
+    custom_fields: {}
+    created: 2020-12-18 00:00:00+00:00
+    last_updated: 2020-12-18 02:17:11.318000+00:00
+    parent: !!python/object:annetbox.v37.models.EntityWithSlug
+      id: 5
+      name: Asia
+      display: Asia
+      url: http://localhost:8037/api/dcim/regions/5/
+      slug: asia

--- a/tests/integration/fixtures/v37/dcim_site_01/cassette.yaml
+++ b/tests/integration/fixtures/v37/dcim_site_01/cassette.yaml
@@ -8,8 +8,6 @@ interactions:
       - gzip, deflate, zstd
       Connection:
       - keep-alive
-      User-Agent:
-      - python-requests/2.33.1
     method: GET
     uri: http://localhost:8037/api/dcim/sites/?limit=5&offset=0
   response:
@@ -62,8 +60,6 @@ interactions:
       - gzip, deflate, zstd
       Connection:
       - keep-alive
-      User-Agent:
-      - python-requests/2.33.1
     method: GET
     uri: http://localhost:8037/api/dcim/sites/24/
   response:

--- a/tests/integration/fixtures/v37/dcim_site_group_01/cassette.yaml
+++ b/tests/integration/fixtures/v37/dcim_site_group_01/cassette.yaml
@@ -1,0 +1,79 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+    method: GET
+    uri: http://localhost:8037/api/dcim/site-groups/?limit=5&offset=0
+  response:
+    body:
+      string: '{"count":3,"next":null,"previous":null,"results":[{"id":1,"url":"http://localhost:8037/api/dcim/site-groups/1/","display":"Customer
+        Sites","name":"Customer Sites","slug":"customer-sites","parent":null,"description":"","tags":[],"custom_fields":{},"created":"2021-12-30T00:00:00Z","last_updated":"2021-12-30T15:41:01.816000Z","site_count":20,"_depth":0},{"id":2,"url":"http://localhost:8037/api/dcim/site-groups/2/","display":"Branch
+        Offices","name":"Branch Offices","slug":"branch-offices","parent":{"id":1,"url":"http://localhost:8037/api/dcim/site-groups/1/","display":"Customer
+        Sites","name":"Customer Sites","slug":"customer-sites","_depth":0},"description":"","tags":[],"custom_fields":{},"created":"2021-12-30T00:00:00Z","last_updated":"2021-12-30T15:41:13.892000Z","site_count":19,"_depth":1},{"id":3,"url":"http://localhost:8037/api/dcim/site-groups/3/","display":"Headquarters","name":"Headquarters","slug":"headquarters","parent":{"id":1,"url":"http://localhost:8037/api/dcim/site-groups/1/","display":"Customer
+        Sites","name":"Customer Sites","slug":"customer-sites","_depth":0},"description":"","tags":[],"custom_fields":{},"created":"2021-12-30T00:00:00Z","last_updated":"2021-12-30T15:41:22.089000Z","site_count":1,"_depth":1}]}'
+    headers:
+      Allow:
+      - GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS
+      Content-Length:
+      - '1241'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - Unit/1.31.1
+      Vary:
+      - HX-Request, Cookie, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+    method: GET
+    uri: http://localhost:8037/api/dcim/site-groups/1/
+  response:
+    body:
+      string: '{"id":1,"url":"http://localhost:8037/api/dcim/site-groups/1/","display":"Customer
+        Sites","name":"Customer Sites","slug":"customer-sites","parent":null,"description":"","tags":[],"custom_fields":{},"created":"2021-12-30T00:00:00Z","last_updated":"2021-12-30T15:41:01.816000Z","site_count":20,"_depth":0}'
+    headers:
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      Content-Length:
+      - '302'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - Unit/1.31.1
+      Vary:
+      - HX-Request, Cookie, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/integration/fixtures/v37/dcim_site_group_01/expected.yaml
+++ b/tests/integration/fixtures/v37/dcim_site_group_01/expected.yaml
@@ -1,0 +1,29 @@
+# AUTO-GENERATED - DO NOT EDIT
+# This file is generated from definitions.yaml
+# To regenerate: python -m tests.integration.generate_fixtures
+
+definition:
+  id: dcim_site_group_01
+  method: dcim_site_group
+  args:
+    site_group_id:
+      call: dcim_site_groups
+      args:
+        limit: 5
+      extract: results[0].id
+call:
+  client_call: dcim_site_group
+  client_call_args: []
+  client_call_kwargs:
+    site_group_id: 1
+output: !!python/object:annetbox.v37.models.SiteGroup
+  id: 1
+  name: Customer Sites
+  display: Customer Sites
+  url: http://localhost:8037/api/dcim/site-groups/1/
+  slug: customer-sites
+  description: ''
+  custom_fields: {}
+  created: 2021-12-30 00:00:00+00:00
+  last_updated: 2021-12-30 15:41:01.816000+00:00
+  parent: null

--- a/tests/integration/fixtures/v37/dcim_site_groups_01/cassette.yaml
+++ b/tests/integration/fixtures/v37/dcim_site_groups_01/cassette.yaml
@@ -1,0 +1,42 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+    method: GET
+    uri: http://localhost:8037/api/dcim/site-groups/?limit=5&offset=0
+  response:
+    body:
+      string: '{"count":3,"next":null,"previous":null,"results":[{"id":1,"url":"http://localhost:8037/api/dcim/site-groups/1/","display":"Customer
+        Sites","name":"Customer Sites","slug":"customer-sites","parent":null,"description":"","tags":[],"custom_fields":{},"created":"2021-12-30T00:00:00Z","last_updated":"2021-12-30T15:41:01.816000Z","site_count":20,"_depth":0},{"id":2,"url":"http://localhost:8037/api/dcim/site-groups/2/","display":"Branch
+        Offices","name":"Branch Offices","slug":"branch-offices","parent":{"id":1,"url":"http://localhost:8037/api/dcim/site-groups/1/","display":"Customer
+        Sites","name":"Customer Sites","slug":"customer-sites","_depth":0},"description":"","tags":[],"custom_fields":{},"created":"2021-12-30T00:00:00Z","last_updated":"2021-12-30T15:41:13.892000Z","site_count":19,"_depth":1},{"id":3,"url":"http://localhost:8037/api/dcim/site-groups/3/","display":"Headquarters","name":"Headquarters","slug":"headquarters","parent":{"id":1,"url":"http://localhost:8037/api/dcim/site-groups/1/","display":"Customer
+        Sites","name":"Customer Sites","slug":"customer-sites","_depth":0},"description":"","tags":[],"custom_fields":{},"created":"2021-12-30T00:00:00Z","last_updated":"2021-12-30T15:41:22.089000Z","site_count":1,"_depth":1}]}'
+    headers:
+      Allow:
+      - GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS
+      Content-Length:
+      - '1241'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - Unit/1.31.1
+      Vary:
+      - HX-Request, Cookie, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/integration/fixtures/v37/dcim_site_groups_01/expected.yaml
+++ b/tests/integration/fixtures/v37/dcim_site_groups_01/expected.yaml
@@ -1,0 +1,62 @@
+# AUTO-GENERATED - DO NOT EDIT
+# This file is generated from definitions.yaml
+# To regenerate: python -m tests.integration.generate_fixtures
+
+definition:
+  id: dcim_site_groups_01
+  method: dcim_site_groups
+  args:
+    limit: 5
+call:
+  client_call: dcim_site_groups
+  client_call_args: []
+  client_call_kwargs:
+    limit: 5
+output: !!python/object:annetbox.base.models.PagingResponse
+  next: null
+  previous: null
+  count: 3
+  results:
+  - !!python/object:annetbox.v37.models.SiteGroup
+    id: 1
+    name: Customer Sites
+    display: Customer Sites
+    url: http://localhost:8037/api/dcim/site-groups/1/
+    slug: customer-sites
+    description: ''
+    custom_fields: {}
+    created: 2021-12-30 00:00:00+00:00
+    last_updated: 2021-12-30 15:41:01.816000+00:00
+    parent: null
+  - !!python/object:annetbox.v37.models.SiteGroup
+    id: 2
+    name: Branch Offices
+    display: Branch Offices
+    url: http://localhost:8037/api/dcim/site-groups/2/
+    slug: branch-offices
+    description: ''
+    custom_fields: {}
+    created: 2021-12-30 00:00:00+00:00
+    last_updated: 2021-12-30 15:41:13.892000+00:00
+    parent: !!python/object:annetbox.v37.models.EntityWithSlug
+      id: 1
+      name: Customer Sites
+      display: Customer Sites
+      url: http://localhost:8037/api/dcim/site-groups/1/
+      slug: customer-sites
+  - !!python/object:annetbox.v37.models.SiteGroup
+    id: 3
+    name: Headquarters
+    display: Headquarters
+    url: http://localhost:8037/api/dcim/site-groups/3/
+    slug: headquarters
+    description: ''
+    custom_fields: {}
+    created: 2021-12-30 00:00:00+00:00
+    last_updated: 2021-12-30 15:41:22.089000+00:00
+    parent: !!python/object:annetbox.v37.models.EntityWithSlug
+      id: 1
+      name: Customer Sites
+      display: Customer Sites
+      url: http://localhost:8037/api/dcim/site-groups/1/
+      slug: customer-sites

--- a/tests/integration/fixtures/v37/dcim_sites_01/cassette.yaml
+++ b/tests/integration/fixtures/v37/dcim_sites_01/cassette.yaml
@@ -8,8 +8,6 @@ interactions:
       - gzip, deflate, zstd
       Connection:
       - keep-alive
-      User-Agent:
-      - python-requests/2.33.1
     method: GET
     uri: http://localhost:8037/api/dcim/sites/?limit=5&offset=0
   response:

--- a/tests/integration/fixtures/v37/ipam_all_ip_addresses_01/cassette.yaml
+++ b/tests/integration/fixtures/v37/ipam_all_ip_addresses_01/cassette.yaml
@@ -8,8 +8,6 @@ interactions:
       - gzip, deflate, zstd
       Connection:
       - keep-alive
-      User-Agent:
-      - python-requests/2.33.1
     method: GET
     uri: http://localhost:8037/api/ipam/ip-addresses/?limit=50&offset=0
   response:

--- a/tests/integration/fixtures/v37/ipam_ip_address_01/cassette.yaml
+++ b/tests/integration/fixtures/v37/ipam_ip_address_01/cassette.yaml
@@ -8,8 +8,6 @@ interactions:
       - gzip, deflate, zstd
       Connection:
       - keep-alive
-      User-Agent:
-      - python-requests/2.33.1
     method: GET
     uri: http://localhost:8037/api/ipam/ip-addresses/?limit=10&offset=0
   response:
@@ -56,8 +54,6 @@ interactions:
       - gzip, deflate, zstd
       Connection:
       - keep-alive
-      User-Agent:
-      - python-requests/2.33.1
     method: GET
     uri: http://localhost:8037/api/ipam/ip-addresses/31/
   response:

--- a/tests/integration/fixtures/v37/ipam_ip_addresses_01/cassette.yaml
+++ b/tests/integration/fixtures/v37/ipam_ip_addresses_01/cassette.yaml
@@ -8,8 +8,6 @@ interactions:
       - gzip, deflate, zstd
       Connection:
       - keep-alive
-      User-Agent:
-      - python-requests/2.33.1
     method: GET
     uri: http://localhost:8037/api/ipam/ip-addresses/?limit=10&offset=0
   response:

--- a/tests/integration/fixtures/v37/lock.yaml
+++ b/tests/integration/fixtures/v37/lock.yaml
@@ -6,127 +6,127 @@ test_cases:
 - test_case: circuit_dark_fiber_01
   files:
   - path: cassette.yaml
-    sha256: 0c801a28fa86d0a378cea627c1eb30d5a000aeb469e3c7a9239442cb8a6de302
+    sha256: 81550fbe258cd54c0114a415a8f223b84f2ba90c96bfe51e1b7a4a4d04fd7c39
   - path: expected.yaml
     sha256: d933b58b43b48af925815d3b6c1e9dee4be959198543e6db88dd97bc369a3258
 - test_case: circuit_internet_01
   files:
   - path: cassette.yaml
-    sha256: f891ceed7e9f7d547f8862912ed7e387943a3fea284d13e157106e194bf8b144
+    sha256: 84580a3c3ed37b8e627ed92d3f943c5f8d3320bdbeee637fa6ccb252c48f462d
   - path: expected.yaml
     sha256: 38befb84c44a21f01b669f7a5b418d149746d69f4c8c711c23636da2437d3192
 - test_case: circuit_mpls_01
   files:
   - path: cassette.yaml
-    sha256: cfe70b561163f5a7a2681f122110f36307a5235e37e3e71d1da3c2fa9f4cf590
+    sha256: 8219bc5534116133060bf40e4fbe240b3a38c79475f94238d3f168977171f2a9
   - path: expected.yaml
     sha256: 4b5203dd65ba3fd4d89b2e87b93bf73a42f6ca9ec0e7e90ebf209b88571a9705
 - test_case: circuits_dark_fiber_01
   files:
   - path: cassette.yaml
-    sha256: 0e7503cbefdc8cd43011f569dab44f592862d5cb53450b021c2a15fd8a1d3a7c
+    sha256: 898aae577fc3eb5f2853b4b0a3b973ab969bdac35cb49bcf9ca1cb8c0d8f0fa1
   - path: expected.yaml
     sha256: b054784b2b22dec1156074520715b9f2a3a6da91381088f5588c6c8aa39d8a6e
 - test_case: circuits_internet_01
   files:
   - path: cassette.yaml
-    sha256: 0175c3e2812758124819130d06139cefea16eab391b99c863039cf3d56d24dea
+    sha256: ae3e1b1d6bd6f6c83174143a55c0d113aef1a87c6635734649905cff4e030058
   - path: expected.yaml
     sha256: 69a7fa3e996ee4039148fa7c1603d80422dd773780b75a6c4df4c2d4667499ae
 - test_case: circuits_mpls_01
   files:
   - path: cassette.yaml
-    sha256: 89bbfeaffe3b234ef69ff0a76e0aaafa4c288e7f7729ac40924094b8adeb7225
+    sha256: 38916064025842dfd585ea4f0c154a8ab82d58d645777b431d375bc0699416b6
   - path: expected.yaml
     sha256: cc513246796e9f44b186551c2aa94de748d337afb86d76972a181b9df26e2221
 - test_case: dcim_all_devices_01
   files:
   - path: cassette.yaml
-    sha256: 3d1f9cf2a7089826f4c3490afc620991851073eb8b0c8c4c19747d8604ecf4a6
+    sha256: 17833b459bf20ab8425ae6cca07d021ef6b7574b179569aedc22d40e11e05842
   - path: expected.yaml
     sha256: 70c9da1fca0ff9fa2335d93d4e68e6df84a4b4f2d596b3585572c5099c662fda
 - test_case: dcim_all_interfaces_01
   files:
   - path: cassette.yaml
-    sha256: 4daac2eb1c78f5881742920b287b6a3ba2ab21fd4f05764cdaf9a5845fe90410
+    sha256: 3114adb7979fe0a941e6ddcdce7811d44b1f583156c911e857ed710ca5309f3d
   - path: expected.yaml
     sha256: a2363c9c5ceab727a02b44ea333006be360f97c82b419d0333b590d94bd86fdf
 - test_case: dcim_cables_01
   files:
   - path: cassette.yaml
-    sha256: 5af67f96c21ddf5246f5e063cbb4f15dba5f4ae1880d3e5d37007e414d23d76a
+    sha256: eafa1bf714150b5c4f3ca7da2d72d5cc791da8c66c9be58f5fe2c01ffe1ade71
   - path: expected.yaml
     sha256: 9c16843d9e04f84d4f68ee3c9523800fe7de99511bf9dc88bca08ec816508ae7
 - test_case: dcim_console_port_01
   files:
   - path: cassette.yaml
-    sha256: e8eb109adab9516d1cf72d1c189a4b621c3fe985cf36d48be83e94cd720496f6
+    sha256: c9b403d56c655005bda2b28593038284de9de0d75f4d2b1c13667d6904292321
   - path: expected.yaml
     sha256: b30c967c6bac4a5a6db464d2b216595b4720d0e4677700be5a8a3fdace9bda7d
 - test_case: dcim_console_ports_01
   files:
   - path: cassette.yaml
-    sha256: 899057a2e1cbdb4427303af0f752bdaaada1ef7893ceca5981cfc6d1381ba8da
+    sha256: f7fb3a1512ea0a96be00afaeb4ea592ea66f0a46e2f23c04ea593c24c617416b
   - path: expected.yaml
     sha256: 98ea4ccfb9fd740b17c3916164ef88a5c191446a678986ed0e782c5eea213431
 - test_case: dcim_device_01
   files:
   - path: cassette.yaml
-    sha256: e423d9b07cf067bec6af8ae7412a7ebf22d2ec5f2faeaef6bfde9f74540745e2
+    sha256: 99523d841490b0c61439c858e1cd81d1ac5038f9fd5173393948e792c5a2086a
   - path: expected.yaml
     sha256: 1b67901fd3985c3ab45a831ded7e67b41126c156bf30fcea43e63ca4c314416d
 - test_case: dcim_devices_01
   files:
   - path: cassette.yaml
-    sha256: 363452880c1d7da90545255720a730eacbe2a6ff636e9fe1b94590fb37703841
+    sha256: f36551206f9c3b64aa712ee7ecaabd56ed916fcbf51c6a4ace3515ca46db5307
   - path: expected.yaml
     sha256: 994c3e3955d819d4f110a0f825b9de2951e3595c7a46bec1513b70868de4820e
 - test_case: dcim_interface_trace_01
   files:
   - path: cassette.yaml
-    sha256: 31e9c9ff7df82772e814c9a2b50b30e48b12417ccbc26897fa7aa25f76f4cbe7
+    sha256: 34844ca3959d8131d24b7514acf20c5fcf8951e6125c544a4937da48f329b887
   - path: expected.yaml
     sha256: 9a1140f1dcdab5da0f3163f9c0efb9a7a89076b0bb73d27bc0d6f5caac42397a
 - test_case: dcim_interface_trace_02
   files:
   - path: cassette.yaml
-    sha256: fa2b870aa3003ac84eb8bdbeb48ffe8bfb5717697200e2b96f9285bd3c822724
+    sha256: 60c573b4b00c3bbc0665515623a657f000a7e1d186405acfc53be75cc969d366
   - path: expected.yaml
     sha256: 57fe62c1900744949b4d16ae62d2a911ee99fa3cb66fab1e96e7cee0f55c54a4
 - test_case: dcim_interface_trace_03
   files:
   - path: cassette.yaml
-    sha256: eebd39bd76fbce5d25e87a4a69f52c6b3a07f584e51c42454e72f52de8f27a8d
+    sha256: 1741d09596194159f5d1a1f06d2159eb9bf5e9dfcb48ad4aa71cebf99ab33d22
   - path: expected.yaml
     sha256: 1c68c74fcb5480a1805b8527a5fe2cf1b8b2cfa810fc6f5aa9d26f0b7460b906
 - test_case: dcim_site_01
   files:
   - path: cassette.yaml
-    sha256: 35aab7bd043deaadc1891f52778ad348fab10dd7a499457ed4b275153152b580
+    sha256: abb755902e538708e076472fc802f71005078bb7b6d00363aa62809b9a640804
   - path: expected.yaml
     sha256: 7ace4d81d97b6001200963b122cb1f6550e589d7a1b2667e2abf8660d2e70698
 - test_case: dcim_sites_01
   files:
   - path: cassette.yaml
-    sha256: c45307dd9c2b9968abae728938dd9e38355396c9813509d0490bfe2826ace11d
+    sha256: 44fd6cf5bf0b3d82a34773e0c8e0fcd272fb43adbebb616ff0c29a08a4eba9eb
   - path: expected.yaml
     sha256: b84d1e363c7899b3abe1542c0a06964d93f1b41778cfe9c0f3eecf1119b574d7
 - test_case: ipam_all_ip_addresses_01
   files:
   - path: cassette.yaml
-    sha256: 453eae28583c727efdedb5a01847820f690fe15bb3e24c81ead75ac052278680
+    sha256: 4a0b10aec020ad30b296ac03d62d36be61da1f41b5f30d79ef82ba9213cea686
   - path: expected.yaml
     sha256: 3c5c45aad6ec65bcf28f506e979972d6564d999eead464290c144ffce3e32d7b
 - test_case: ipam_ip_address_01
   files:
   - path: cassette.yaml
-    sha256: d4f0e6957dd92104a6cd7f3bb4fd0f1c0cd00dc5eecc52e2f35e286eb9537990
+    sha256: d845db9c7a607165fada76cee748ff0360615859ad0d59977c343d60dba4b12d
   - path: expected.yaml
     sha256: 1cfc0b88c55a94f42e5b8b47efe84581566de182e740e2cd5cb4317a225f44b8
 - test_case: ipam_ip_addresses_01
   files:
   - path: cassette.yaml
-    sha256: a81a435b6fc8ce64b9dd692fea291c4f69c21c45144bb833c51053c859d08edd
+    sha256: c5677ae4509ee12d240828cfaad811f5c44a557b232711e2252c5d05156a058a
   - path: expected.yaml
     sha256: 86dfbd7cc8a28fddd678ba3936451aa44ad049db1daf29e28edcb4638d62c9ac
-sha256: 41b9f18c0217f5daa4270400a5b742b2aa88e9f217ddc53ed31214292fe73e06
+sha256: a0213b20e2fc0b34cc6a9cb025b65c5f4d609b2194347cb85de5a068eb692fa0

--- a/tests/integration/fixtures/v37/lock.yaml
+++ b/tests/integration/fixtures/v37/lock.yaml
@@ -99,12 +99,48 @@ test_cases:
     sha256: 1741d09596194159f5d1a1f06d2159eb9bf5e9dfcb48ad4aa71cebf99ab33d22
   - path: expected.yaml
     sha256: 1c68c74fcb5480a1805b8527a5fe2cf1b8b2cfa810fc6f5aa9d26f0b7460b906
+- test_case: dcim_location_01
+  files:
+  - path: cassette.yaml
+    sha256: c31ae1c5d96ffe8bf50eaca99300ce7b5f0dae2865dc93e7b4a448907effcc2d
+  - path: expected.yaml
+    sha256: f56e6625827e9c299ef843836ac93ee9bba68c8d1444e57adaba04c96b5248e7
+- test_case: dcim_locations_01
+  files:
+  - path: cassette.yaml
+    sha256: 573f48983f102a3131a3ad4b63379a6cb66da2a29ebf2d3fafd07fbe46d7e1c2
+  - path: expected.yaml
+    sha256: e9815c1dd6085acd0ce9f034c6c323a905f21c965894fe543e1b81576801fa1e
+- test_case: dcim_region_01
+  files:
+  - path: cassette.yaml
+    sha256: 6580c10c28e16b2903aa725668b0c2c40c768d2770ae6effc05b910930b7da64
+  - path: expected.yaml
+    sha256: 0ab925f1fdadd50d08f18669c38255ac0ce2a0c9cb9990695fed14a59ea6d416
+- test_case: dcim_regions_01
+  files:
+  - path: cassette.yaml
+    sha256: e345754640428c2509c7dc18aa1fb244b5da4ac2648a30766eb2fbbf1ea24700
+  - path: expected.yaml
+    sha256: 62e3fe9f92c6dc5031f2a9c165ed8b0c51f9e014089266876eb01b3e9a07b23d
 - test_case: dcim_site_01
   files:
   - path: cassette.yaml
     sha256: abb755902e538708e076472fc802f71005078bb7b6d00363aa62809b9a640804
   - path: expected.yaml
     sha256: 7ace4d81d97b6001200963b122cb1f6550e589d7a1b2667e2abf8660d2e70698
+- test_case: dcim_site_group_01
+  files:
+  - path: cassette.yaml
+    sha256: bf1e78cd820ecc31fc973d353c4d040509c9008f6b3cff53447540c76e5e0e76
+  - path: expected.yaml
+    sha256: 8e1c9f2862b803b6b9903c15983d6f92e42a1346708d976e1e4d95e8f1fb896b
+- test_case: dcim_site_groups_01
+  files:
+  - path: cassette.yaml
+    sha256: fb52bb25ac8212a704fa3309e9e489d7fde98bf721eee1c9ade935c8bcfbac38
+  - path: expected.yaml
+    sha256: 89b01702ce4118dbd20f8107648ab91faf67d9127ee972bfada25534c7fcc6aa
 - test_case: dcim_sites_01
   files:
   - path: cassette.yaml
@@ -129,4 +165,16 @@ test_cases:
     sha256: c5677ae4509ee12d240828cfaad811f5c44a557b232711e2252c5d05156a058a
   - path: expected.yaml
     sha256: 86dfbd7cc8a28fddd678ba3936451aa44ad049db1daf29e28edcb4638d62c9ac
-sha256: a0213b20e2fc0b34cc6a9cb025b65c5f4d609b2194347cb85de5a068eb692fa0
+- test_case: tenancy_tenant_group_01
+  files:
+  - path: cassette.yaml
+    sha256: 555da63a9c1315dff383e50dfe539ed3f009f8f26bd53c0fb66066653e097383
+  - path: expected.yaml
+    sha256: fb93a053ce412afa201451e4acce3e214c6710e9efc8f322fc9ad95e6df5fb7f
+- test_case: tenancy_tenant_groups_01
+  files:
+  - path: cassette.yaml
+    sha256: e02bb1cc3af095e7f40ebb1a30dd0eacb85e7fa4b2276cd9519d801c667b7366
+  - path: expected.yaml
+    sha256: b999a355f50695dc0d2ed7ffb4cb67fe8d094b58505eb7f5076beeefd099de02
+sha256: 4aec78688db3f117093f5f037847a6a9a43033f7ee58a1f7c18b7edb8bdc53f0

--- a/tests/integration/fixtures/v37/tenancy_tenant_group_01/cassette.yaml
+++ b/tests/integration/fixtures/v37/tenancy_tenant_group_01/cassette.yaml
@@ -1,0 +1,74 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+    method: GET
+    uri: http://localhost:8037/api/tenancy/tenant-groups/?limit=5&offset=0
+  response:
+    body:
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":1,"url":"http://localhost:8037/api/tenancy/tenant-groups/1/","display":"Customers","name":"Customers","slug":"customers","parent":null,"description":"","tags":[],"custom_fields":{},"created":"2020-12-19T00:00:00Z","last_updated":"2020-12-19T02:43:53.309000Z","tenant_count":11,"_depth":0}]}'
+    headers:
+      Allow:
+      - GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS
+      Content-Length:
+      - '346'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - Unit/1.31.1
+      Vary:
+      - HX-Request, Cookie, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+    method: GET
+    uri: http://localhost:8037/api/tenancy/tenant-groups/1/
+  response:
+    body:
+      string: '{"id":1,"url":"http://localhost:8037/api/tenancy/tenant-groups/1/","display":"Customers","name":"Customers","slug":"customers","parent":null,"description":"","tags":[],"custom_fields":{},"created":"2020-12-19T00:00:00Z","last_updated":"2020-12-19T02:43:53.309000Z","tenant_count":11,"_depth":0}'
+    headers:
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      Content-Length:
+      - '294'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - Unit/1.31.1
+      Vary:
+      - HX-Request, Cookie, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/integration/fixtures/v37/tenancy_tenant_group_01/expected.yaml
+++ b/tests/integration/fixtures/v37/tenancy_tenant_group_01/expected.yaml
@@ -1,0 +1,29 @@
+# AUTO-GENERATED - DO NOT EDIT
+# This file is generated from definitions.yaml
+# To regenerate: python -m tests.integration.generate_fixtures
+
+definition:
+  id: tenancy_tenant_group_01
+  method: tenancy_tenant_group
+  args:
+    tenant_group_id:
+      call: tenancy_tenant_groups
+      args:
+        limit: 5
+      extract: results[0].id
+call:
+  client_call: tenancy_tenant_group
+  client_call_args: []
+  client_call_kwargs:
+    tenant_group_id: 1
+output: !!python/object:annetbox.v37.models.TenantGroup
+  id: 1
+  name: Customers
+  display: Customers
+  url: http://localhost:8037/api/tenancy/tenant-groups/1/
+  slug: customers
+  description: ''
+  custom_fields: {}
+  created: 2020-12-19 00:00:00+00:00
+  last_updated: 2020-12-19 02:43:53.309000+00:00
+  parent: null

--- a/tests/integration/fixtures/v37/tenancy_tenant_groups_01/cassette.yaml
+++ b/tests/integration/fixtures/v37/tenancy_tenant_groups_01/cassette.yaml
@@ -1,0 +1,38 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+    method: GET
+    uri: http://localhost:8037/api/tenancy/tenant-groups/?limit=5&offset=0
+  response:
+    body:
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":1,"url":"http://localhost:8037/api/tenancy/tenant-groups/1/","display":"Customers","name":"Customers","slug":"customers","parent":null,"description":"","tags":[],"custom_fields":{},"created":"2020-12-19T00:00:00Z","last_updated":"2020-12-19T02:43:53.309000Z","tenant_count":11,"_depth":0}]}'
+    headers:
+      Allow:
+      - GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS
+      Content-Length:
+      - '346'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - Unit/1.31.1
+      Vary:
+      - HX-Request, Cookie, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/integration/fixtures/v37/tenancy_tenant_groups_01/expected.yaml
+++ b/tests/integration/fixtures/v37/tenancy_tenant_groups_01/expected.yaml
@@ -1,0 +1,30 @@
+# AUTO-GENERATED - DO NOT EDIT
+# This file is generated from definitions.yaml
+# To regenerate: python -m tests.integration.generate_fixtures
+
+definition:
+  id: tenancy_tenant_groups_01
+  method: tenancy_tenant_groups
+  args:
+    limit: 5
+call:
+  client_call: tenancy_tenant_groups
+  client_call_args: []
+  client_call_kwargs:
+    limit: 5
+output: !!python/object:annetbox.base.models.PagingResponse
+  next: null
+  previous: null
+  count: 1
+  results:
+  - !!python/object:annetbox.v37.models.TenantGroup
+    id: 1
+    name: Customers
+    display: Customers
+    url: http://localhost:8037/api/tenancy/tenant-groups/1/
+    slug: customers
+    description: ''
+    custom_fields: {}
+    created: 2020-12-19 00:00:00+00:00
+    last_updated: 2020-12-19 02:43:53.309000+00:00
+    parent: null

--- a/tests/integration/fixtures/v41/circuit_dark_fiber_01/cassette.yaml
+++ b/tests/integration/fixtures/v41/circuit_dark_fiber_01/cassette.yaml
@@ -8,8 +8,6 @@ interactions:
       - gzip, deflate, zstd
       Connection:
       - keep-alive
-      User-Agent:
-      - python-requests/2.33.1
     method: GET
     uri: http://localhost:8041/api/circuits/circuits/?limit=1&offset=0&type=dark-fiber
   response:
@@ -55,8 +53,6 @@ interactions:
       - gzip, deflate, zstd
       Connection:
       - keep-alive
-      User-Agent:
-      - python-requests/2.33.1
     method: GET
     uri: http://localhost:8041/api/circuits/circuits/30/
   response:

--- a/tests/integration/fixtures/v41/circuit_internet_01/cassette.yaml
+++ b/tests/integration/fixtures/v41/circuit_internet_01/cassette.yaml
@@ -8,8 +8,6 @@ interactions:
       - gzip, deflate, zstd
       Connection:
       - keep-alive
-      User-Agent:
-      - python-requests/2.33.1
     method: GET
     uri: http://localhost:8041/api/circuits/circuits/?limit=1&offset=0&type=internet
   response:
@@ -51,8 +49,6 @@ interactions:
       - gzip, deflate, zstd
       Connection:
       - keep-alive
-      User-Agent:
-      - python-requests/2.33.1
     method: GET
     uri: http://localhost:8041/api/circuits/circuits/19/
   response:

--- a/tests/integration/fixtures/v41/circuit_mpls_01/cassette.yaml
+++ b/tests/integration/fixtures/v41/circuit_mpls_01/cassette.yaml
@@ -8,8 +8,6 @@ interactions:
       - gzip, deflate, zstd
       Connection:
       - keep-alive
-      User-Agent:
-      - python-requests/2.33.1
     method: GET
     uri: http://localhost:8041/api/circuits/circuits/?limit=1&offset=0&type=mpls
   response:
@@ -53,8 +51,6 @@ interactions:
       - gzip, deflate, zstd
       Connection:
       - keep-alive
-      User-Agent:
-      - python-requests/2.33.1
     method: GET
     uri: http://localhost:8041/api/circuits/circuits/14/
   response:

--- a/tests/integration/fixtures/v41/circuits_dark_fiber_01/cassette.yaml
+++ b/tests/integration/fixtures/v41/circuits_dark_fiber_01/cassette.yaml
@@ -8,8 +8,6 @@ interactions:
       - gzip, deflate, zstd
       Connection:
       - keep-alive
-      User-Agent:
-      - python-requests/2.33.1
     method: GET
     uri: http://localhost:8041/api/circuits/circuits/?limit=20&offset=0&type=dark-fiber
   response:

--- a/tests/integration/fixtures/v41/circuits_internet_01/cassette.yaml
+++ b/tests/integration/fixtures/v41/circuits_internet_01/cassette.yaml
@@ -8,8 +8,6 @@ interactions:
       - gzip, deflate, zstd
       Connection:
       - keep-alive
-      User-Agent:
-      - python-requests/2.33.1
     method: GET
     uri: http://localhost:8041/api/circuits/circuits/?limit=20&offset=0&type=internet
   response:

--- a/tests/integration/fixtures/v41/circuits_mpls_01/cassette.yaml
+++ b/tests/integration/fixtures/v41/circuits_mpls_01/cassette.yaml
@@ -8,8 +8,6 @@ interactions:
       - gzip, deflate, zstd
       Connection:
       - keep-alive
-      User-Agent:
-      - python-requests/2.33.1
     method: GET
     uri: http://localhost:8041/api/circuits/circuits/?limit=20&offset=0&type=mpls
   response:

--- a/tests/integration/fixtures/v41/dcim_all_devices_01/cassette.yaml
+++ b/tests/integration/fixtures/v41/dcim_all_devices_01/cassette.yaml
@@ -8,8 +8,6 @@ interactions:
       - gzip, deflate, zstd
       Connection:
       - keep-alive
-      User-Agent:
-      - python-requests/2.33.1
     method: GET
     uri: http://localhost:8041/api/dcim/devices/?limit=30&offset=0
   response:

--- a/tests/integration/fixtures/v41/dcim_all_interfaces_01/cassette.yaml
+++ b/tests/integration/fixtures/v41/dcim_all_interfaces_01/cassette.yaml
@@ -8,8 +8,6 @@ interactions:
       - gzip, deflate, zstd
       Connection:
       - keep-alive
-      User-Agent:
-      - python-requests/2.33.1
     method: GET
     uri: http://localhost:8041/api/dcim/interfaces/?device_id=1&device_id=2&device_id=3&device_id=4&device_id=5&device_id=6&device_id=7&device_id=8&device_id=9&device_id=10&limit=100&offset=0
   response:
@@ -173,8 +171,6 @@ interactions:
       - gzip, deflate, zstd
       Connection:
       - keep-alive
-      User-Agent:
-      - python-requests/2.33.1
     method: GET
     uri: http://localhost:8041/api/dcim/interfaces/?device_id=1&device_id=2&device_id=3&device_id=4&device_id=5&device_id=6&device_id=7&device_id=8&device_id=9&device_id=10&limit=100&offset=100
   response:
@@ -258,8 +254,6 @@ interactions:
       - gzip, deflate, zstd
       Connection:
       - keep-alive
-      User-Agent:
-      - python-requests/2.33.1
     method: GET
     uri: http://localhost:8041/api/dcim/interfaces/?device_id=11&device_id=12&device_id=13&limit=100&offset=0
   response:

--- a/tests/integration/fixtures/v41/dcim_cables_01/cassette.yaml
+++ b/tests/integration/fixtures/v41/dcim_cables_01/cassette.yaml
@@ -8,8 +8,6 @@ interactions:
       - gzip, deflate, zstd
       Connection:
       - keep-alive
-      User-Agent:
-      - python-requests/2.33.1
     method: GET
     uri: http://localhost:8041/api/dcim/cables/?limit=5&offset=0
   response:

--- a/tests/integration/fixtures/v41/dcim_console_port_01/cassette.yaml
+++ b/tests/integration/fixtures/v41/dcim_console_port_01/cassette.yaml
@@ -8,8 +8,6 @@ interactions:
       - gzip, deflate, zstd
       Connection:
       - keep-alive
-      User-Agent:
-      - python-requests/2.33.1
     method: GET
     uri: http://localhost:8041/api/dcim/console-ports/?limit=5&offset=0
   response:
@@ -56,8 +54,6 @@ interactions:
       - gzip, deflate, zstd
       Connection:
       - keep-alive
-      User-Agent:
-      - python-requests/2.33.1
     method: GET
     uri: http://localhost:8041/api/dcim/console-ports/1/
   response:

--- a/tests/integration/fixtures/v41/dcim_console_ports_01/cassette.yaml
+++ b/tests/integration/fixtures/v41/dcim_console_ports_01/cassette.yaml
@@ -8,8 +8,6 @@ interactions:
       - gzip, deflate, zstd
       Connection:
       - keep-alive
-      User-Agent:
-      - python-requests/2.33.1
     method: GET
     uri: http://localhost:8041/api/dcim/console-ports/?limit=5&offset=0
   response:

--- a/tests/integration/fixtures/v41/dcim_device_01/cassette.yaml
+++ b/tests/integration/fixtures/v41/dcim_device_01/cassette.yaml
@@ -8,8 +8,6 @@ interactions:
       - gzip, deflate, zstd
       Connection:
       - keep-alive
-      User-Agent:
-      - python-requests/2.33.1
     method: GET
     uri: http://localhost:8041/api/dcim/devices/?limit=10&offset=0
   response:
@@ -93,8 +91,6 @@ interactions:
       - gzip, deflate, zstd
       Connection:
       - keep-alive
-      User-Agent:
-      - python-requests/2.33.1
     method: GET
     uri: http://localhost:8041/api/dcim/devices/88/
   response:

--- a/tests/integration/fixtures/v41/dcim_devices_01/cassette.yaml
+++ b/tests/integration/fixtures/v41/dcim_devices_01/cassette.yaml
@@ -8,8 +8,6 @@ interactions:
       - gzip, deflate, zstd
       Connection:
       - keep-alive
-      User-Agent:
-      - python-requests/2.33.1
     method: GET
     uri: http://localhost:8041/api/dcim/devices/?limit=10&offset=0
   response:

--- a/tests/integration/fixtures/v41/dcim_interface_trace_01/cassette.yaml
+++ b/tests/integration/fixtures/v41/dcim_interface_trace_01/cassette.yaml
@@ -8,8 +8,6 @@ interactions:
       - gzip, deflate, zstd
       Connection:
       - keep-alive
-      User-Agent:
-      - python-requests/2.33.1
     method: GET
     uri: http://localhost:8041/api/dcim/interfaces/28/trace/
   response:

--- a/tests/integration/fixtures/v41/dcim_interface_trace_02/cassette.yaml
+++ b/tests/integration/fixtures/v41/dcim_interface_trace_02/cassette.yaml
@@ -8,8 +8,6 @@ interactions:
       - gzip, deflate, zstd
       Connection:
       - keep-alive
-      User-Agent:
-      - python-requests/2.33.1
     method: GET
     uri: http://localhost:8041/api/dcim/interfaces/157/trace/
   response:

--- a/tests/integration/fixtures/v41/dcim_interface_trace_03/cassette.yaml
+++ b/tests/integration/fixtures/v41/dcim_interface_trace_03/cassette.yaml
@@ -8,8 +8,6 @@ interactions:
       - gzip, deflate, zstd
       Connection:
       - keep-alive
-      User-Agent:
-      - python-requests/2.33.1
     method: GET
     uri: http://localhost:8041/api/dcim/interfaces/969/trace/
   response:

--- a/tests/integration/fixtures/v41/dcim_location_01/cassette.yaml
+++ b/tests/integration/fixtures/v41/dcim_location_01/cassette.yaml
@@ -1,0 +1,88 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+    method: GET
+    uri: http://localhost:8041/api/dcim/locations/?limit=5&offset=0
+  response:
+    body:
+      string: '{"count":4,"next":null,"previous":null,"results":[{"id":1,"url":"http://localhost:8041/api/dcim/locations/1/","display_url":"http://localhost:8041/dcim/locations/1/","display":"Row
+        1","name":"Row 1","slug":"row-1","site":{"id":21,"url":"http://localhost:8041/api/dcim/sites/21/","display":"MDF","name":"MDF","slug":"ncsu-065","description":"Main
+        Distribution Frame"},"parent":null,"status":{"value":"active","label":"Active"},"tenant":null,"facility":"","description":"","tags":[],"custom_fields":{},"created":"2021-04-02T00:00:00Z","last_updated":"2021-04-02T16:57:17.398000Z","rack_count":8,"device_count":10,"_depth":0},{"id":2,"url":"http://localhost:8041/api/dcim/locations/2/","display_url":"http://localhost:8041/dcim/locations/2/","display":"Row
+        2","name":"Row 2","slug":"row-2","site":{"id":21,"url":"http://localhost:8041/api/dcim/sites/21/","display":"MDF","name":"MDF","slug":"ncsu-065","description":"Main
+        Distribution Frame"},"parent":null,"status":{"value":"active","label":"Active"},"tenant":null,"facility":"","description":"","tags":[],"custom_fields":{},"created":"2021-04-02T00:00:00Z","last_updated":"2021-04-02T16:57:24.629000Z","rack_count":8,"device_count":1,"_depth":0},{"id":3,"url":"http://localhost:8041/api/dcim/locations/3/","display_url":"http://localhost:8041/dcim/locations/3/","display":"Row
+        3","name":"Row 3","slug":"row-3","site":{"id":21,"url":"http://localhost:8041/api/dcim/sites/21/","display":"MDF","name":"MDF","slug":"ncsu-065","description":"Main
+        Distribution Frame"},"parent":null,"status":{"value":"active","label":"Active"},"tenant":null,"facility":"","description":"","tags":[],"custom_fields":{},"created":"2021-04-02T00:00:00Z","last_updated":"2021-04-02T16:57:31.713000Z","rack_count":8,"device_count":0,"_depth":0},{"id":4,"url":"http://localhost:8041/api/dcim/locations/4/","display_url":"http://localhost:8041/dcim/locations/4/","display":"Row
+        4","name":"Row 4","slug":"row-4","site":{"id":21,"url":"http://localhost:8041/api/dcim/sites/21/","display":"MDF","name":"MDF","slug":"ncsu-065","description":"Main
+        Distribution Frame"},"parent":null,"status":{"value":"active","label":"Active"},"tenant":null,"facility":"","description":"","tags":[],"custom_fields":{},"created":"2021-04-02T00:00:00Z","last_updated":"2021-04-02T16:57:37.732000Z","rack_count":0,"device_count":0,"_depth":0}]}'
+    headers:
+      Allow:
+      - GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS
+      Content-Language:
+      - en
+      Content-Length:
+      - '2340'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - Unit/1.33.0
+      Vary:
+      - HX-Request, Accept-Language, Cookie, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+    method: GET
+    uri: http://localhost:8041/api/dcim/locations/1/
+  response:
+    body:
+      string: '{"id":1,"url":"http://localhost:8041/api/dcim/locations/1/","display_url":"http://localhost:8041/dcim/locations/1/","display":"Row
+        1","name":"Row 1","slug":"row-1","site":{"id":21,"url":"http://localhost:8041/api/dcim/sites/21/","display":"MDF","name":"MDF","slug":"ncsu-065","description":"Main
+        Distribution Frame"},"parent":null,"status":{"value":"active","label":"Active"},"tenant":null,"facility":"","description":"","tags":[],"custom_fields":{},"created":"2021-04-02T00:00:00Z","last_updated":"2021-04-02T16:57:17.398000Z","rack_count":8,"device_count":10,"_depth":0}'
+    headers:
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      Content-Language:
+      - en
+      Content-Length:
+      - '572'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - Unit/1.33.0
+      Vary:
+      - HX-Request, Accept-Language, Cookie, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/integration/fixtures/v41/dcim_location_01/expected.yaml
+++ b/tests/integration/fixtures/v41/dcim_location_01/expected.yaml
@@ -1,0 +1,39 @@
+# AUTO-GENERATED - DO NOT EDIT
+# This file is generated from definitions.yaml
+# To regenerate: python -m tests.integration.generate_fixtures
+
+definition:
+  id: dcim_location_01
+  method: dcim_location
+  args:
+    location_id:
+      call: dcim_locations
+      args:
+        limit: 5
+      extract: results[0].id
+call:
+  client_call: dcim_location
+  client_call_args: []
+  client_call_kwargs:
+    location_id: 1
+output: !!python/object:annetbox.v41.models.Location
+  id: 1
+  name: Row 1
+  display: Row 1
+  url: http://localhost:8041/api/dcim/locations/1/
+  slug: row-1
+  site: !!python/object:annetbox.v41.models.Entity
+    id: 21
+    name: MDF
+    display: MDF
+    url: http://localhost:8041/api/dcim/sites/21/
+  status: !!python/object:annetbox.v41.models.Label
+    value: active
+    label: Active
+  description: ''
+  custom_fields: {}
+  created: 2021-04-02 00:00:00+00:00
+  last_updated: 2021-04-02 16:57:17.398000+00:00
+  parent: null
+  tenant: null
+  facility: ''

--- a/tests/integration/fixtures/v41/dcim_locations_01/cassette.yaml
+++ b/tests/integration/fixtures/v41/dcim_locations_01/cassette.yaml
@@ -1,0 +1,48 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+    method: GET
+    uri: http://localhost:8041/api/dcim/locations/?limit=5&offset=0
+  response:
+    body:
+      string: '{"count":4,"next":null,"previous":null,"results":[{"id":1,"url":"http://localhost:8041/api/dcim/locations/1/","display_url":"http://localhost:8041/dcim/locations/1/","display":"Row
+        1","name":"Row 1","slug":"row-1","site":{"id":21,"url":"http://localhost:8041/api/dcim/sites/21/","display":"MDF","name":"MDF","slug":"ncsu-065","description":"Main
+        Distribution Frame"},"parent":null,"status":{"value":"active","label":"Active"},"tenant":null,"facility":"","description":"","tags":[],"custom_fields":{},"created":"2021-04-02T00:00:00Z","last_updated":"2021-04-02T16:57:17.398000Z","rack_count":8,"device_count":10,"_depth":0},{"id":2,"url":"http://localhost:8041/api/dcim/locations/2/","display_url":"http://localhost:8041/dcim/locations/2/","display":"Row
+        2","name":"Row 2","slug":"row-2","site":{"id":21,"url":"http://localhost:8041/api/dcim/sites/21/","display":"MDF","name":"MDF","slug":"ncsu-065","description":"Main
+        Distribution Frame"},"parent":null,"status":{"value":"active","label":"Active"},"tenant":null,"facility":"","description":"","tags":[],"custom_fields":{},"created":"2021-04-02T00:00:00Z","last_updated":"2021-04-02T16:57:24.629000Z","rack_count":8,"device_count":1,"_depth":0},{"id":3,"url":"http://localhost:8041/api/dcim/locations/3/","display_url":"http://localhost:8041/dcim/locations/3/","display":"Row
+        3","name":"Row 3","slug":"row-3","site":{"id":21,"url":"http://localhost:8041/api/dcim/sites/21/","display":"MDF","name":"MDF","slug":"ncsu-065","description":"Main
+        Distribution Frame"},"parent":null,"status":{"value":"active","label":"Active"},"tenant":null,"facility":"","description":"","tags":[],"custom_fields":{},"created":"2021-04-02T00:00:00Z","last_updated":"2021-04-02T16:57:31.713000Z","rack_count":8,"device_count":0,"_depth":0},{"id":4,"url":"http://localhost:8041/api/dcim/locations/4/","display_url":"http://localhost:8041/dcim/locations/4/","display":"Row
+        4","name":"Row 4","slug":"row-4","site":{"id":21,"url":"http://localhost:8041/api/dcim/sites/21/","display":"MDF","name":"MDF","slug":"ncsu-065","description":"Main
+        Distribution Frame"},"parent":null,"status":{"value":"active","label":"Active"},"tenant":null,"facility":"","description":"","tags":[],"custom_fields":{},"created":"2021-04-02T00:00:00Z","last_updated":"2021-04-02T16:57:37.732000Z","rack_count":0,"device_count":0,"_depth":0}]}'
+    headers:
+      Allow:
+      - GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS
+      Content-Language:
+      - en
+      Content-Length:
+      - '2340'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - Unit/1.33.0
+      Vary:
+      - HX-Request, Accept-Language, Cookie, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/integration/fixtures/v41/dcim_locations_01/expected.yaml
+++ b/tests/integration/fixtures/v41/dcim_locations_01/expected.yaml
@@ -1,0 +1,103 @@
+# AUTO-GENERATED - DO NOT EDIT
+# This file is generated from definitions.yaml
+# To regenerate: python -m tests.integration.generate_fixtures
+
+definition:
+  id: dcim_locations_01
+  method: dcim_locations
+  args:
+    limit: 5
+call:
+  client_call: dcim_locations
+  client_call_args: []
+  client_call_kwargs:
+    limit: 5
+output: !!python/object:annetbox.base.models.PagingResponse
+  next: null
+  previous: null
+  count: 4
+  results:
+  - !!python/object:annetbox.v41.models.Location
+    id: 1
+    name: Row 1
+    display: Row 1
+    url: http://localhost:8041/api/dcim/locations/1/
+    slug: row-1
+    site: !!python/object:annetbox.v41.models.Entity
+      id: 21
+      name: MDF
+      display: MDF
+      url: http://localhost:8041/api/dcim/sites/21/
+    status: !!python/object:annetbox.v41.models.Label
+      value: active
+      label: Active
+    description: ''
+    custom_fields: {}
+    created: 2021-04-02 00:00:00+00:00
+    last_updated: 2021-04-02 16:57:17.398000+00:00
+    parent: null
+    tenant: null
+    facility: ''
+  - !!python/object:annetbox.v41.models.Location
+    id: 2
+    name: Row 2
+    display: Row 2
+    url: http://localhost:8041/api/dcim/locations/2/
+    slug: row-2
+    site: !!python/object:annetbox.v41.models.Entity
+      id: 21
+      name: MDF
+      display: MDF
+      url: http://localhost:8041/api/dcim/sites/21/
+    status: !!python/object:annetbox.v41.models.Label
+      value: active
+      label: Active
+    description: ''
+    custom_fields: {}
+    created: 2021-04-02 00:00:00+00:00
+    last_updated: 2021-04-02 16:57:24.629000+00:00
+    parent: null
+    tenant: null
+    facility: ''
+  - !!python/object:annetbox.v41.models.Location
+    id: 3
+    name: Row 3
+    display: Row 3
+    url: http://localhost:8041/api/dcim/locations/3/
+    slug: row-3
+    site: !!python/object:annetbox.v41.models.Entity
+      id: 21
+      name: MDF
+      display: MDF
+      url: http://localhost:8041/api/dcim/sites/21/
+    status: !!python/object:annetbox.v41.models.Label
+      value: active
+      label: Active
+    description: ''
+    custom_fields: {}
+    created: 2021-04-02 00:00:00+00:00
+    last_updated: 2021-04-02 16:57:31.713000+00:00
+    parent: null
+    tenant: null
+    facility: ''
+  - !!python/object:annetbox.v41.models.Location
+    id: 4
+    name: Row 4
+    display: Row 4
+    url: http://localhost:8041/api/dcim/locations/4/
+    slug: row-4
+    site: !!python/object:annetbox.v41.models.Entity
+      id: 21
+      name: MDF
+      display: MDF
+      url: http://localhost:8041/api/dcim/sites/21/
+    status: !!python/object:annetbox.v41.models.Label
+      value: active
+      label: Active
+    description: ''
+    custom_fields: {}
+    created: 2021-04-02 00:00:00+00:00
+    last_updated: 2021-04-02 16:57:37.732000+00:00
+    parent: null
+    tenant: null
+    facility: ''

--- a/tests/integration/fixtures/v41/dcim_region_01/cassette.yaml
+++ b/tests/integration/fixtures/v41/dcim_region_01/cassette.yaml
@@ -1,0 +1,78 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+    method: GET
+    uri: http://localhost:8041/api/dcim/regions/?limit=5&offset=0
+  response:
+    body:
+      string: '{"count":67,"next":"http://localhost:8041/api/dcim/regions/?limit=5&offset=5","previous":null,"results":[{"id":4,"url":"http://localhost:8041/api/dcim/regions/4/","display_url":"http://localhost:8041/dcim/regions/4/","display":"Africa","name":"Africa","slug":"africa","parent":null,"description":"","tags":[],"custom_fields":{},"created":"2020-12-18T00:00:00Z","last_updated":"2020-12-18T02:10:30.332000Z","site_count":0,"_depth":0},{"id":5,"url":"http://localhost:8041/api/dcim/regions/5/","display_url":"http://localhost:8041/dcim/regions/5/","display":"Asia","name":"Asia","slug":"asia","parent":null,"description":"","tags":[],"custom_fields":{},"created":"2020-12-18T00:00:00Z","last_updated":"2020-12-18T02:10:30.367000Z","site_count":0,"_depth":0},{"id":15,"url":"http://localhost:8041/api/dcim/regions/15/","display_url":"http://localhost:8041/dcim/regions/15/","display":"China","name":"China","slug":"cn","parent":{"id":5,"url":"http://localhost:8041/api/dcim/regions/5/","display_url":"http://localhost:8041/dcim/regions/5/","display":"Asia","name":"Asia","slug":"asia","_depth":0},"description":"","tags":[],"custom_fields":{},"created":"2020-12-18T00:00:00Z","last_updated":"2020-12-18T02:17:11.368000Z","site_count":0,"_depth":1},{"id":16,"url":"http://localhost:8041/api/dcim/regions/16/","display_url":"http://localhost:8041/dcim/regions/16/","display":"India","name":"India","slug":"in","parent":{"id":5,"url":"http://localhost:8041/api/dcim/regions/5/","display_url":"http://localhost:8041/dcim/regions/5/","display":"Asia","name":"Asia","slug":"asia","_depth":0},"description":"","tags":[],"custom_fields":{},"created":"2020-12-18T00:00:00Z","last_updated":"2020-12-18T02:17:11.423000Z","site_count":0,"_depth":1},{"id":14,"url":"http://localhost:8041/api/dcim/regions/14/","display_url":"http://localhost:8041/dcim/regions/14/","display":"Singapore","name":"Singapore","slug":"sg","parent":{"id":5,"url":"http://localhost:8041/api/dcim/regions/5/","display_url":"http://localhost:8041/dcim/regions/5/","display":"Asia","name":"Asia","slug":"asia","_depth":0},"description":"","tags":[],"custom_fields":{},"created":"2020-12-18T00:00:00Z","last_updated":"2020-12-18T02:17:11.318000Z","site_count":0,"_depth":1}]}'
+    headers:
+      Allow:
+      - GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS
+      Content-Language:
+      - en
+      Content-Length:
+      - '2231'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - Unit/1.33.0
+      Vary:
+      - HX-Request, Accept-Language, Cookie, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+    method: GET
+    uri: http://localhost:8041/api/dcim/regions/4/
+  response:
+    body:
+      string: '{"id":4,"url":"http://localhost:8041/api/dcim/regions/4/","display_url":"http://localhost:8041/dcim/regions/4/","display":"Africa","name":"Africa","slug":"africa","parent":null,"description":"","tags":[],"custom_fields":{},"created":"2020-12-18T00:00:00Z","last_updated":"2020-12-18T02:10:30.332000Z","site_count":0,"_depth":0}'
+    headers:
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      Content-Language:
+      - en
+      Content-Length:
+      - '327'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - Unit/1.33.0
+      Vary:
+      - HX-Request, Accept-Language, Cookie, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/integration/fixtures/v41/dcim_region_01/expected.yaml
+++ b/tests/integration/fixtures/v41/dcim_region_01/expected.yaml
@@ -1,0 +1,29 @@
+# AUTO-GENERATED - DO NOT EDIT
+# This file is generated from definitions.yaml
+# To regenerate: python -m tests.integration.generate_fixtures
+
+definition:
+  id: dcim_region_01
+  method: dcim_region
+  args:
+    region_id:
+      call: dcim_regions
+      args:
+        limit: 5
+      extract: results[0].id
+call:
+  client_call: dcim_region
+  client_call_args: []
+  client_call_kwargs:
+    region_id: 4
+output: !!python/object:annetbox.v41.models.Region
+  id: 4
+  name: Africa
+  display: Africa
+  url: http://localhost:8041/api/dcim/regions/4/
+  slug: africa
+  description: ''
+  custom_fields: {}
+  created: 2020-12-18 00:00:00+00:00
+  last_updated: 2020-12-18 02:10:30.332000+00:00
+  parent: null

--- a/tests/integration/fixtures/v41/dcim_regions_01/cassette.yaml
+++ b/tests/integration/fixtures/v41/dcim_regions_01/cassette.yaml
@@ -1,0 +1,40 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+    method: GET
+    uri: http://localhost:8041/api/dcim/regions/?limit=5&offset=0
+  response:
+    body:
+      string: '{"count":67,"next":"http://localhost:8041/api/dcim/regions/?limit=5&offset=5","previous":null,"results":[{"id":4,"url":"http://localhost:8041/api/dcim/regions/4/","display_url":"http://localhost:8041/dcim/regions/4/","display":"Africa","name":"Africa","slug":"africa","parent":null,"description":"","tags":[],"custom_fields":{},"created":"2020-12-18T00:00:00Z","last_updated":"2020-12-18T02:10:30.332000Z","site_count":0,"_depth":0},{"id":5,"url":"http://localhost:8041/api/dcim/regions/5/","display_url":"http://localhost:8041/dcim/regions/5/","display":"Asia","name":"Asia","slug":"asia","parent":null,"description":"","tags":[],"custom_fields":{},"created":"2020-12-18T00:00:00Z","last_updated":"2020-12-18T02:10:30.367000Z","site_count":0,"_depth":0},{"id":15,"url":"http://localhost:8041/api/dcim/regions/15/","display_url":"http://localhost:8041/dcim/regions/15/","display":"China","name":"China","slug":"cn","parent":{"id":5,"url":"http://localhost:8041/api/dcim/regions/5/","display_url":"http://localhost:8041/dcim/regions/5/","display":"Asia","name":"Asia","slug":"asia","_depth":0},"description":"","tags":[],"custom_fields":{},"created":"2020-12-18T00:00:00Z","last_updated":"2020-12-18T02:17:11.368000Z","site_count":0,"_depth":1},{"id":16,"url":"http://localhost:8041/api/dcim/regions/16/","display_url":"http://localhost:8041/dcim/regions/16/","display":"India","name":"India","slug":"in","parent":{"id":5,"url":"http://localhost:8041/api/dcim/regions/5/","display_url":"http://localhost:8041/dcim/regions/5/","display":"Asia","name":"Asia","slug":"asia","_depth":0},"description":"","tags":[],"custom_fields":{},"created":"2020-12-18T00:00:00Z","last_updated":"2020-12-18T02:17:11.423000Z","site_count":0,"_depth":1},{"id":14,"url":"http://localhost:8041/api/dcim/regions/14/","display_url":"http://localhost:8041/dcim/regions/14/","display":"Singapore","name":"Singapore","slug":"sg","parent":{"id":5,"url":"http://localhost:8041/api/dcim/regions/5/","display_url":"http://localhost:8041/dcim/regions/5/","display":"Asia","name":"Asia","slug":"asia","_depth":0},"description":"","tags":[],"custom_fields":{},"created":"2020-12-18T00:00:00Z","last_updated":"2020-12-18T02:17:11.318000Z","site_count":0,"_depth":1}]}'
+    headers:
+      Allow:
+      - GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS
+      Content-Language:
+      - en
+      Content-Length:
+      - '2231'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - Unit/1.33.0
+      Vary:
+      - HX-Request, Accept-Language, Cookie, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/integration/fixtures/v41/dcim_regions_01/expected.yaml
+++ b/tests/integration/fixtures/v41/dcim_regions_01/expected.yaml
@@ -1,0 +1,89 @@
+# AUTO-GENERATED - DO NOT EDIT
+# This file is generated from definitions.yaml
+# To regenerate: python -m tests.integration.generate_fixtures
+
+definition:
+  id: dcim_regions_01
+  method: dcim_regions
+  args:
+    limit: 5
+call:
+  client_call: dcim_regions
+  client_call_args: []
+  client_call_kwargs:
+    limit: 5
+output: !!python/object:annetbox.base.models.PagingResponse
+  next: http://localhost:8041/api/dcim/regions/?limit=5&offset=5
+  previous: null
+  count: 67
+  results:
+  - !!python/object:annetbox.v41.models.Region
+    id: 4
+    name: Africa
+    display: Africa
+    url: http://localhost:8041/api/dcim/regions/4/
+    slug: africa
+    description: ''
+    custom_fields: {}
+    created: 2020-12-18 00:00:00+00:00
+    last_updated: 2020-12-18 02:10:30.332000+00:00
+    parent: null
+  - !!python/object:annetbox.v41.models.Region
+    id: 5
+    name: Asia
+    display: Asia
+    url: http://localhost:8041/api/dcim/regions/5/
+    slug: asia
+    description: ''
+    custom_fields: {}
+    created: 2020-12-18 00:00:00+00:00
+    last_updated: 2020-12-18 02:10:30.367000+00:00
+    parent: null
+  - !!python/object:annetbox.v41.models.Region
+    id: 15
+    name: China
+    display: China
+    url: http://localhost:8041/api/dcim/regions/15/
+    slug: cn
+    description: ''
+    custom_fields: {}
+    created: 2020-12-18 00:00:00+00:00
+    last_updated: 2020-12-18 02:17:11.368000+00:00
+    parent: !!python/object:annetbox.v41.models.EntityWithSlug
+      id: 5
+      name: Asia
+      display: Asia
+      url: http://localhost:8041/api/dcim/regions/5/
+      slug: asia
+  - !!python/object:annetbox.v41.models.Region
+    id: 16
+    name: India
+    display: India
+    url: http://localhost:8041/api/dcim/regions/16/
+    slug: in
+    description: ''
+    custom_fields: {}
+    created: 2020-12-18 00:00:00+00:00
+    last_updated: 2020-12-18 02:17:11.423000+00:00
+    parent: !!python/object:annetbox.v41.models.EntityWithSlug
+      id: 5
+      name: Asia
+      display: Asia
+      url: http://localhost:8041/api/dcim/regions/5/
+      slug: asia
+  - !!python/object:annetbox.v41.models.Region
+    id: 14
+    name: Singapore
+    display: Singapore
+    url: http://localhost:8041/api/dcim/regions/14/
+    slug: sg
+    description: ''
+    custom_fields: {}
+    created: 2020-12-18 00:00:00+00:00
+    last_updated: 2020-12-18 02:17:11.318000+00:00
+    parent: !!python/object:annetbox.v41.models.EntityWithSlug
+      id: 5
+      name: Asia
+      display: Asia
+      url: http://localhost:8041/api/dcim/regions/5/
+      slug: asia

--- a/tests/integration/fixtures/v41/dcim_site_01/cassette.yaml
+++ b/tests/integration/fixtures/v41/dcim_site_01/cassette.yaml
@@ -8,8 +8,6 @@ interactions:
       - gzip, deflate, zstd
       Connection:
       - keep-alive
-      User-Agent:
-      - python-requests/2.33.1
     method: GET
     uri: http://localhost:8041/api/dcim/sites/?limit=5&offset=0
   response:
@@ -64,8 +62,6 @@ interactions:
       - gzip, deflate, zstd
       Connection:
       - keep-alive
-      User-Agent:
-      - python-requests/2.33.1
     method: GET
     uri: http://localhost:8041/api/dcim/sites/24/
   response:

--- a/tests/integration/fixtures/v41/dcim_site_group_01/cassette.yaml
+++ b/tests/integration/fixtures/v41/dcim_site_group_01/cassette.yaml
@@ -1,0 +1,83 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+    method: GET
+    uri: http://localhost:8041/api/dcim/site-groups/?limit=5&offset=0
+  response:
+    body:
+      string: '{"count":3,"next":null,"previous":null,"results":[{"id":1,"url":"http://localhost:8041/api/dcim/site-groups/1/","display_url":"http://localhost:8041/dcim/site-groups/1/","display":"Customer
+        Sites","name":"Customer Sites","slug":"customer-sites","parent":null,"description":"","tags":[],"custom_fields":{},"created":"2021-12-30T00:00:00Z","last_updated":"2021-12-30T15:41:01.816000Z","site_count":20,"_depth":0},{"id":2,"url":"http://localhost:8041/api/dcim/site-groups/2/","display_url":"http://localhost:8041/dcim/site-groups/2/","display":"Branch
+        Offices","name":"Branch Offices","slug":"branch-offices","parent":{"id":1,"url":"http://localhost:8041/api/dcim/site-groups/1/","display_url":"http://localhost:8041/dcim/site-groups/1/","display":"Customer
+        Sites","name":"Customer Sites","slug":"customer-sites","_depth":0},"description":"","tags":[],"custom_fields":{},"created":"2021-12-30T00:00:00Z","last_updated":"2021-12-30T15:41:13.892000Z","site_count":19,"_depth":1},{"id":3,"url":"http://localhost:8041/api/dcim/site-groups/3/","display_url":"http://localhost:8041/dcim/site-groups/3/","display":"Headquarters","name":"Headquarters","slug":"headquarters","parent":{"id":1,"url":"http://localhost:8041/api/dcim/site-groups/1/","display_url":"http://localhost:8041/dcim/site-groups/1/","display":"Customer
+        Sites","name":"Customer Sites","slug":"customer-sites","_depth":0},"description":"","tags":[],"custom_fields":{},"created":"2021-12-30T00:00:00Z","last_updated":"2021-12-30T15:41:22.089000Z","site_count":1,"_depth":1}]}'
+    headers:
+      Allow:
+      - GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS
+      Content-Language:
+      - en
+      Content-Length:
+      - '1531'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - Unit/1.33.0
+      Vary:
+      - HX-Request, Accept-Language, Cookie, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+    method: GET
+    uri: http://localhost:8041/api/dcim/site-groups/1/
+  response:
+    body:
+      string: '{"id":1,"url":"http://localhost:8041/api/dcim/site-groups/1/","display_url":"http://localhost:8041/dcim/site-groups/1/","display":"Customer
+        Sites","name":"Customer Sites","slug":"customer-sites","parent":null,"description":"","tags":[],"custom_fields":{},"created":"2021-12-30T00:00:00Z","last_updated":"2021-12-30T15:41:01.816000Z","site_count":20,"_depth":0}'
+    headers:
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      Content-Language:
+      - en
+      Content-Length:
+      - '360'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - Unit/1.33.0
+      Vary:
+      - HX-Request, Accept-Language, Cookie, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/integration/fixtures/v41/dcim_site_group_01/expected.yaml
+++ b/tests/integration/fixtures/v41/dcim_site_group_01/expected.yaml
@@ -1,0 +1,29 @@
+# AUTO-GENERATED - DO NOT EDIT
+# This file is generated from definitions.yaml
+# To regenerate: python -m tests.integration.generate_fixtures
+
+definition:
+  id: dcim_site_group_01
+  method: dcim_site_group
+  args:
+    site_group_id:
+      call: dcim_site_groups
+      args:
+        limit: 5
+      extract: results[0].id
+call:
+  client_call: dcim_site_group
+  client_call_args: []
+  client_call_kwargs:
+    site_group_id: 1
+output: !!python/object:annetbox.v41.models.SiteGroup
+  id: 1
+  name: Customer Sites
+  display: Customer Sites
+  url: http://localhost:8041/api/dcim/site-groups/1/
+  slug: customer-sites
+  description: ''
+  custom_fields: {}
+  created: 2021-12-30 00:00:00+00:00
+  last_updated: 2021-12-30 15:41:01.816000+00:00
+  parent: null

--- a/tests/integration/fixtures/v41/dcim_site_groups_01/cassette.yaml
+++ b/tests/integration/fixtures/v41/dcim_site_groups_01/cassette.yaml
@@ -1,0 +1,44 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+    method: GET
+    uri: http://localhost:8041/api/dcim/site-groups/?limit=5&offset=0
+  response:
+    body:
+      string: '{"count":3,"next":null,"previous":null,"results":[{"id":1,"url":"http://localhost:8041/api/dcim/site-groups/1/","display_url":"http://localhost:8041/dcim/site-groups/1/","display":"Customer
+        Sites","name":"Customer Sites","slug":"customer-sites","parent":null,"description":"","tags":[],"custom_fields":{},"created":"2021-12-30T00:00:00Z","last_updated":"2021-12-30T15:41:01.816000Z","site_count":20,"_depth":0},{"id":2,"url":"http://localhost:8041/api/dcim/site-groups/2/","display_url":"http://localhost:8041/dcim/site-groups/2/","display":"Branch
+        Offices","name":"Branch Offices","slug":"branch-offices","parent":{"id":1,"url":"http://localhost:8041/api/dcim/site-groups/1/","display_url":"http://localhost:8041/dcim/site-groups/1/","display":"Customer
+        Sites","name":"Customer Sites","slug":"customer-sites","_depth":0},"description":"","tags":[],"custom_fields":{},"created":"2021-12-30T00:00:00Z","last_updated":"2021-12-30T15:41:13.892000Z","site_count":19,"_depth":1},{"id":3,"url":"http://localhost:8041/api/dcim/site-groups/3/","display_url":"http://localhost:8041/dcim/site-groups/3/","display":"Headquarters","name":"Headquarters","slug":"headquarters","parent":{"id":1,"url":"http://localhost:8041/api/dcim/site-groups/1/","display_url":"http://localhost:8041/dcim/site-groups/1/","display":"Customer
+        Sites","name":"Customer Sites","slug":"customer-sites","_depth":0},"description":"","tags":[],"custom_fields":{},"created":"2021-12-30T00:00:00Z","last_updated":"2021-12-30T15:41:22.089000Z","site_count":1,"_depth":1}]}'
+    headers:
+      Allow:
+      - GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS
+      Content-Language:
+      - en
+      Content-Length:
+      - '1531'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - Unit/1.33.0
+      Vary:
+      - HX-Request, Accept-Language, Cookie, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/integration/fixtures/v41/dcim_site_groups_01/expected.yaml
+++ b/tests/integration/fixtures/v41/dcim_site_groups_01/expected.yaml
@@ -1,0 +1,62 @@
+# AUTO-GENERATED - DO NOT EDIT
+# This file is generated from definitions.yaml
+# To regenerate: python -m tests.integration.generate_fixtures
+
+definition:
+  id: dcim_site_groups_01
+  method: dcim_site_groups
+  args:
+    limit: 5
+call:
+  client_call: dcim_site_groups
+  client_call_args: []
+  client_call_kwargs:
+    limit: 5
+output: !!python/object:annetbox.base.models.PagingResponse
+  next: null
+  previous: null
+  count: 3
+  results:
+  - !!python/object:annetbox.v41.models.SiteGroup
+    id: 1
+    name: Customer Sites
+    display: Customer Sites
+    url: http://localhost:8041/api/dcim/site-groups/1/
+    slug: customer-sites
+    description: ''
+    custom_fields: {}
+    created: 2021-12-30 00:00:00+00:00
+    last_updated: 2021-12-30 15:41:01.816000+00:00
+    parent: null
+  - !!python/object:annetbox.v41.models.SiteGroup
+    id: 2
+    name: Branch Offices
+    display: Branch Offices
+    url: http://localhost:8041/api/dcim/site-groups/2/
+    slug: branch-offices
+    description: ''
+    custom_fields: {}
+    created: 2021-12-30 00:00:00+00:00
+    last_updated: 2021-12-30 15:41:13.892000+00:00
+    parent: !!python/object:annetbox.v41.models.EntityWithSlug
+      id: 1
+      name: Customer Sites
+      display: Customer Sites
+      url: http://localhost:8041/api/dcim/site-groups/1/
+      slug: customer-sites
+  - !!python/object:annetbox.v41.models.SiteGroup
+    id: 3
+    name: Headquarters
+    display: Headquarters
+    url: http://localhost:8041/api/dcim/site-groups/3/
+    slug: headquarters
+    description: ''
+    custom_fields: {}
+    created: 2021-12-30 00:00:00+00:00
+    last_updated: 2021-12-30 15:41:22.089000+00:00
+    parent: !!python/object:annetbox.v41.models.EntityWithSlug
+      id: 1
+      name: Customer Sites
+      display: Customer Sites
+      url: http://localhost:8041/api/dcim/site-groups/1/
+      slug: customer-sites

--- a/tests/integration/fixtures/v41/dcim_sites_01/cassette.yaml
+++ b/tests/integration/fixtures/v41/dcim_sites_01/cassette.yaml
@@ -8,8 +8,6 @@ interactions:
       - gzip, deflate, zstd
       Connection:
       - keep-alive
-      User-Agent:
-      - python-requests/2.33.1
     method: GET
     uri: http://localhost:8041/api/dcim/sites/?limit=5&offset=0
   response:

--- a/tests/integration/fixtures/v41/ipam_all_ip_addresses_01/cassette.yaml
+++ b/tests/integration/fixtures/v41/ipam_all_ip_addresses_01/cassette.yaml
@@ -8,8 +8,6 @@ interactions:
       - gzip, deflate, zstd
       Connection:
       - keep-alive
-      User-Agent:
-      - python-requests/2.33.1
     method: GET
     uri: http://localhost:8041/api/ipam/ip-addresses/?limit=50&offset=0
   response:

--- a/tests/integration/fixtures/v41/ipam_ip_address_01/cassette.yaml
+++ b/tests/integration/fixtures/v41/ipam_ip_address_01/cassette.yaml
@@ -8,8 +8,6 @@ interactions:
       - gzip, deflate, zstd
       Connection:
       - keep-alive
-      User-Agent:
-      - python-requests/2.33.1
     method: GET
     uri: http://localhost:8041/api/ipam/ip-addresses/?limit=10&offset=0
   response:
@@ -58,8 +56,6 @@ interactions:
       - gzip, deflate, zstd
       Connection:
       - keep-alive
-      User-Agent:
-      - python-requests/2.33.1
     method: GET
     uri: http://localhost:8041/api/ipam/ip-addresses/31/
   response:

--- a/tests/integration/fixtures/v41/ipam_ip_addresses_01/cassette.yaml
+++ b/tests/integration/fixtures/v41/ipam_ip_addresses_01/cassette.yaml
@@ -8,8 +8,6 @@ interactions:
       - gzip, deflate, zstd
       Connection:
       - keep-alive
-      User-Agent:
-      - python-requests/2.33.1
     method: GET
     uri: http://localhost:8041/api/ipam/ip-addresses/?limit=10&offset=0
   response:

--- a/tests/integration/fixtures/v41/lock.yaml
+++ b/tests/integration/fixtures/v41/lock.yaml
@@ -6,127 +6,127 @@ test_cases:
 - test_case: circuit_dark_fiber_01
   files:
   - path: cassette.yaml
-    sha256: 38d512a319b4d8675776add3034fc5fad0cb2131ab6856ea549a3ce91510920c
+    sha256: 6edc246f060a31f5a20425fc40b989bd82ad2e54fb550b98db5e6348fc9d2e25
   - path: expected.yaml
     sha256: 25bc8f7ce57183c3f20d63ba73e3ac6e426c8177a106312c9bac3a2eadbf7760
 - test_case: circuit_internet_01
   files:
   - path: cassette.yaml
-    sha256: 26dbcaf0e869d758e1d6ffa0ff66c35e3c56a6595b13c398f38eddf2bb9fcb69
+    sha256: 0d0870a1cb6e62834d4f87f0d0f96e22c20382b7ae51c9aea21392c5811293ec
   - path: expected.yaml
     sha256: 65b6be7b650fabe6536915349841e6d6560a12b09b57024a2e4d92adb121434b
 - test_case: circuit_mpls_01
   files:
   - path: cassette.yaml
-    sha256: f88b14a1eefa531897902b2c641d57002bc84ffabdd64e0600cc2614ee597e64
+    sha256: 801230ee6683cc6ba797f0b352e9239db0b3003a7db5e72ecd24609366475629
   - path: expected.yaml
     sha256: 71628f8c8f581564ba6f08bf7a71db3077e0ae4518ab55a755a0cc75ed687dde
 - test_case: circuits_dark_fiber_01
   files:
   - path: cassette.yaml
-    sha256: 14c5238e431d9d6e7dbbcef8e1df9489e9fcc25b02d06d71cf07caa314cd32de
+    sha256: 27992ed53c29d63fc4329ecde019e864f40b0a06fc99f522fcd1cd904b7b748a
   - path: expected.yaml
     sha256: d11f123d8ba951858a01cd9de85c2c8cc4ad0fa1311dca99a4b2a21219813ada
 - test_case: circuits_internet_01
   files:
   - path: cassette.yaml
-    sha256: 998766dbd745c74bafdf23fab8067959fe2772e5469454cce5981bd891e999cf
+    sha256: 1a0fb52551822a673cb2a284f8a0a8b2537aa25b0d53ce6e2d1abf66a24a91e6
   - path: expected.yaml
     sha256: 564a8f9004b7763a85d2cfea4b8dd210d1eb01ddd1b7c3f167f607a832c4751f
 - test_case: circuits_mpls_01
   files:
   - path: cassette.yaml
-    sha256: 8100a01c9e992e5875216f920434c83f44518a417f3a971e7e2c3a9c72f74ab1
+    sha256: 40cc7346898b7a5fd30b994b9bf96bde27b9014dda564ed5d4a01ec13df0b2e6
   - path: expected.yaml
     sha256: a4ebc7d6e46b7ad882ef119d1256e363de695bff8a6ebd6b62015fc67f0506f0
 - test_case: dcim_all_devices_01
   files:
   - path: cassette.yaml
-    sha256: f20b2e9f43559a45618d88d6957249e4c57e9ecb194dd4dbc2017e1aaeeebd8d
+    sha256: bfc4daec83b2529210f73a3e7632975d664e305e612bea61ec6a9574eb051765
   - path: expected.yaml
     sha256: 5fe6dc67fdd80959f88c3dc30c5fc2a817403aecf708a4ecfe86861438822ea7
 - test_case: dcim_all_interfaces_01
   files:
   - path: cassette.yaml
-    sha256: 3509f609b76fdabb86e380a3e9829ab2ff16dac5f7d20598c759f3b29d6ce1bc
+    sha256: 7c7b65f1c10e04c29a1ff6a0f77ca9b713e98ffa091dc80b0b9a94e4f4b2432e
   - path: expected.yaml
     sha256: c9c5f4856f803b149e8df92d6662b70c75c2aa40d1924168a567a7c5f216234d
 - test_case: dcim_cables_01
   files:
   - path: cassette.yaml
-    sha256: 9984c71d45cf87c26f6c1d9c901665e27ccfd5bfd8751ea13fd23f64a653bbba
+    sha256: 3fe35c0285fc9f5822974721d80b1588d088f005d24337e5a65fc0465dfe92f3
   - path: expected.yaml
     sha256: c9fab22724c46dc8df5adf5828e096d18da676f958a0c4ba62ca9e620a985b9e
 - test_case: dcim_console_port_01
   files:
   - path: cassette.yaml
-    sha256: 773a5d9925a97a73153f4d85a0a67cc0a1fe1f6bf453be18aaf602d9d92bba35
+    sha256: b135465956cdfd79e0bfc7a42dbcecb05d328d915c81057ba0916bbafbb25bde
   - path: expected.yaml
     sha256: c2abe0555a136f171586a71727f9dc1aad79f7bc2fbc767e8f37547cfe329bd8
 - test_case: dcim_console_ports_01
   files:
   - path: cassette.yaml
-    sha256: 87371b1d9015a3b8b54f12c795b79b3327c841447062448b79149536a3b98558
+    sha256: cea50a84fc8f3b6520eb10163c466af658473b03e08758aba4736994609150d3
   - path: expected.yaml
     sha256: 2a68416810379da2208f404702fac79e3140e81d3e80a09af58a78e1d85e205f
 - test_case: dcim_device_01
   files:
   - path: cassette.yaml
-    sha256: 08f398805132cae9b8b651a09f1cdb2d62a8b0d189235778a6906305dd1433e0
+    sha256: 147719c1874fd4672e2e91a52b6d73c41a4e48d5691ffa5d844a793cc607e947
   - path: expected.yaml
     sha256: 6fd72e505838001cb3113e8727e03aed804e9883e83fc6c1778481d9a7a4032d
 - test_case: dcim_devices_01
   files:
   - path: cassette.yaml
-    sha256: 0f959119ca48b2af140319c9646bcaa0b5219347fadfed9e56cb5b819614f9f2
+    sha256: 836310f1f247925279af57b6ce36dd2cc99e8695abb2292289c3ef23b1eff43f
   - path: expected.yaml
     sha256: c654fb9f2516c7575e768ed31275a2ce9dd9aff7e64f50a47f59d40ac5926b62
 - test_case: dcim_interface_trace_01
   files:
   - path: cassette.yaml
-    sha256: 53d04d08fbd10571065338ade96e71999470c617045e8b3c2f3f83d765f330b1
+    sha256: 66c284ad5bf983ccee2e9f4d2a7798a40f9df23276f9b223fc9518e96af7cbaa
   - path: expected.yaml
     sha256: 88b910424f8ba2621f3b1a40663e0df3eed266ce1fec0ee7cf8354101230ca0d
 - test_case: dcim_interface_trace_02
   files:
   - path: cassette.yaml
-    sha256: 2ef45ca5832987edc4f921bd916d047ef6ba63134b9cf3de1b5fbe3d1815ea17
+    sha256: 4c3144975813ae869270675bf805d9dfaa7649304e73ceb5da6353236e6b407d
   - path: expected.yaml
     sha256: 23be18825b38081675e5bf5b5f495908627b6115e215097215371aae7fb32dcc
 - test_case: dcim_interface_trace_03
   files:
   - path: cassette.yaml
-    sha256: bb691602478e6a9243d2013e0af244cc4e85b718c3657372e50042509b8ab8aa
+    sha256: 5224fe051fe171d9f9dfcbef38605658f0619f66e8359be2f5d0b035535b9f45
   - path: expected.yaml
     sha256: 77470aa44809660a3635de265164b4010b4a5b1a611d37aaf90a5fc9e81fa359
 - test_case: dcim_site_01
   files:
   - path: cassette.yaml
-    sha256: 7e8e790690391a8f80bc1a43447c39f1e3126baf9b5cb982d7985522952bee31
+    sha256: 51c43e3c157baaf0639a06246de96ab25913f5c03bb2943239cada93321d0c87
   - path: expected.yaml
     sha256: 87d71ec80096618164ebe4de1bcbc39d416fd091aae7de1bf6839e9e4fec5ae9
 - test_case: dcim_sites_01
   files:
   - path: cassette.yaml
-    sha256: 2f41c19ae0d8943c984349b2fcc3ef442206e839ee93f2246e53f3e1d39a0456
+    sha256: 4a703352b015b9ebc01e55a0b77a47ac9f247e687f9d9a613c25e6a26b3b0d18
   - path: expected.yaml
     sha256: f7a77a2eb82d1a489c659ee7338b374add3075edf95d3944145f2e04fcf167f6
 - test_case: ipam_all_ip_addresses_01
   files:
   - path: cassette.yaml
-    sha256: 49bb1098cb11cd5020ca54758d5b4c6762204a2411bc9f302f8817eed704aa6c
+    sha256: 16a865893c3a8deb915e46b36115bf1db633bd0f801ec591c103e24a2bc4aefc
   - path: expected.yaml
     sha256: df1249d6f3efd240b27df3d12112d306bfca7ed1630979ac4b24d1b546e8cdfb
 - test_case: ipam_ip_address_01
   files:
   - path: cassette.yaml
-    sha256: eab6a9744695d07014a196f7dcee1c2742620d33c8e8a888a00ae39c1295eaff
+    sha256: f1f3d86cb8588adb106580bc88b838f04c9df34f15e3c79b19c144b6a04ebf1b
   - path: expected.yaml
     sha256: f0f86735aa1ff91a6a78cef766d5b296123e0e5c99451feaceaf555f30191cc2
 - test_case: ipam_ip_addresses_01
   files:
   - path: cassette.yaml
-    sha256: 63f76435008c461066429fefc49274269b7dd0b8fd2f147732249e36f69e06b1
+    sha256: 5310c162ef4bf01883e02c83f5435b35b04c18f86d3ec3588a9f7653d0626389
   - path: expected.yaml
     sha256: 8b15abc0b6415a4fdecf96cb3e7c4a84804e949ca6698475965f62819bf2c4eb
-sha256: cfb6afc993e3b1b940c3dbfc8b811aa7062e0676270d9d75da41f52a2301ff41
+sha256: b08cceed40d85a546c342e6086b5435b006910e3023931e0dc06ff9c43ceb0a6

--- a/tests/integration/fixtures/v41/lock.yaml
+++ b/tests/integration/fixtures/v41/lock.yaml
@@ -99,12 +99,48 @@ test_cases:
     sha256: 5224fe051fe171d9f9dfcbef38605658f0619f66e8359be2f5d0b035535b9f45
   - path: expected.yaml
     sha256: 77470aa44809660a3635de265164b4010b4a5b1a611d37aaf90a5fc9e81fa359
+- test_case: dcim_location_01
+  files:
+  - path: cassette.yaml
+    sha256: d30edb3f47b112aa457b3e3a9abe0a88359ce3d8eccfed803f02c8babbfbdea3
+  - path: expected.yaml
+    sha256: aa2e89f63ce0f13d88337ea3adc64a46916cd307ead4316cceaf3c4517159e41
+- test_case: dcim_locations_01
+  files:
+  - path: cassette.yaml
+    sha256: be004819835fb0919729aa83be3e37572a224c9893e6835c8c1065fcc7b9b7f2
+  - path: expected.yaml
+    sha256: cf950e80c8aca4cfa8caab78af6278a06c033494c55d8eba879c536775cbab9d
+- test_case: dcim_region_01
+  files:
+  - path: cassette.yaml
+    sha256: 8640ea7cc58c37d8c82ae5d491dc6a135f84a98a52fbedf4ccbc3f1ece6a2e0e
+  - path: expected.yaml
+    sha256: f6266396bb9af8f006e8629db9324c8658787f17a03c44c7f22e3ef5c5b60b74
+- test_case: dcim_regions_01
+  files:
+  - path: cassette.yaml
+    sha256: c2810cf49778b353bb2e1cba2820639de520e47e46fb615e878a15d29c71f1cd
+  - path: expected.yaml
+    sha256: 05e0b58564a9a2eded7b89dc58dfcaf7064c6425b011fccfddddd26a50e1b77c
 - test_case: dcim_site_01
   files:
   - path: cassette.yaml
     sha256: 51c43e3c157baaf0639a06246de96ab25913f5c03bb2943239cada93321d0c87
   - path: expected.yaml
     sha256: 87d71ec80096618164ebe4de1bcbc39d416fd091aae7de1bf6839e9e4fec5ae9
+- test_case: dcim_site_group_01
+  files:
+  - path: cassette.yaml
+    sha256: ffa4db9d9166345842e091484440d8cac03b5f2e16b0efe277ab44c4cfa3a11e
+  - path: expected.yaml
+    sha256: 0b1a964ce898e15c1cf33b413a2535c96d057c945ca343940f4a6029d2b92b77
+- test_case: dcim_site_groups_01
+  files:
+  - path: cassette.yaml
+    sha256: 35524bd8dd1ac7cbdd7ca3283e6ddf6f7795d943eac2c36a5f1515949014c172
+  - path: expected.yaml
+    sha256: 081c7d892aa0d491e5f767e674d7e8b82ed85a2b72900fb4b45969f9ebd99d04
 - test_case: dcim_sites_01
   files:
   - path: cassette.yaml
@@ -129,4 +165,16 @@ test_cases:
     sha256: 5310c162ef4bf01883e02c83f5435b35b04c18f86d3ec3588a9f7653d0626389
   - path: expected.yaml
     sha256: 8b15abc0b6415a4fdecf96cb3e7c4a84804e949ca6698475965f62819bf2c4eb
-sha256: b08cceed40d85a546c342e6086b5435b006910e3023931e0dc06ff9c43ceb0a6
+- test_case: tenancy_tenant_group_01
+  files:
+  - path: cassette.yaml
+    sha256: 164cd4f2a65bf5a4a873773aeeebe4e2e3b5c806d5034b8fdd2299744c32d4cc
+  - path: expected.yaml
+    sha256: faad74b2dd8ffb04440c937ea2cb3713795f5611591fa5cd5b2fa54ae21f7ec0
+- test_case: tenancy_tenant_groups_01
+  files:
+  - path: cassette.yaml
+    sha256: 20eaedb9f39f39894b50de919a9a0202517deaa4282aefd9948abcaf2645ab9a
+  - path: expected.yaml
+    sha256: 0c56677cf032b51d8603194f0df0943c679b525a455bc12ead8d53194f14487d
+sha256: 1d7da9fec3c09e281fcf8c8bb846563a231abc2b42f9ac028c04d29ef8f87e12

--- a/tests/integration/fixtures/v41/tenancy_tenant_group_01/cassette.yaml
+++ b/tests/integration/fixtures/v41/tenancy_tenant_group_01/cassette.yaml
@@ -1,0 +1,78 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+    method: GET
+    uri: http://localhost:8041/api/tenancy/tenant-groups/?limit=5&offset=0
+  response:
+    body:
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":1,"url":"http://localhost:8041/api/tenancy/tenant-groups/1/","display_url":"http://localhost:8041/tenancy/tenant-groups/1/","display":"Customers","name":"Customers","slug":"customers","parent":null,"description":"","tags":[],"custom_fields":{},"created":"2020-12-19T00:00:00Z","last_updated":"2020-12-19T02:43:53.309000Z","tenant_count":11,"_depth":0}]}'
+    headers:
+      Allow:
+      - GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS
+      Content-Language:
+      - en
+      Content-Length:
+      - '409'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - Unit/1.33.0
+      Vary:
+      - HX-Request, Accept-Language, Cookie, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+    method: GET
+    uri: http://localhost:8041/api/tenancy/tenant-groups/1/
+  response:
+    body:
+      string: '{"id":1,"url":"http://localhost:8041/api/tenancy/tenant-groups/1/","display_url":"http://localhost:8041/tenancy/tenant-groups/1/","display":"Customers","name":"Customers","slug":"customers","parent":null,"description":"","tags":[],"custom_fields":{},"created":"2020-12-19T00:00:00Z","last_updated":"2020-12-19T02:43:53.309000Z","tenant_count":11,"_depth":0}'
+    headers:
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      Content-Language:
+      - en
+      Content-Length:
+      - '357'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - Unit/1.33.0
+      Vary:
+      - HX-Request, Accept-Language, Cookie, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/integration/fixtures/v41/tenancy_tenant_group_01/expected.yaml
+++ b/tests/integration/fixtures/v41/tenancy_tenant_group_01/expected.yaml
@@ -1,0 +1,29 @@
+# AUTO-GENERATED - DO NOT EDIT
+# This file is generated from definitions.yaml
+# To regenerate: python -m tests.integration.generate_fixtures
+
+definition:
+  id: tenancy_tenant_group_01
+  method: tenancy_tenant_group
+  args:
+    tenant_group_id:
+      call: tenancy_tenant_groups
+      args:
+        limit: 5
+      extract: results[0].id
+call:
+  client_call: tenancy_tenant_group
+  client_call_args: []
+  client_call_kwargs:
+    tenant_group_id: 1
+output: !!python/object:annetbox.v41.models.TenantGroup
+  id: 1
+  name: Customers
+  display: Customers
+  url: http://localhost:8041/api/tenancy/tenant-groups/1/
+  slug: customers
+  description: ''
+  custom_fields: {}
+  created: 2020-12-19 00:00:00+00:00
+  last_updated: 2020-12-19 02:43:53.309000+00:00
+  parent: null

--- a/tests/integration/fixtures/v41/tenancy_tenant_groups_01/cassette.yaml
+++ b/tests/integration/fixtures/v41/tenancy_tenant_groups_01/cassette.yaml
@@ -1,0 +1,40 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+    method: GET
+    uri: http://localhost:8041/api/tenancy/tenant-groups/?limit=5&offset=0
+  response:
+    body:
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":1,"url":"http://localhost:8041/api/tenancy/tenant-groups/1/","display_url":"http://localhost:8041/tenancy/tenant-groups/1/","display":"Customers","name":"Customers","slug":"customers","parent":null,"description":"","tags":[],"custom_fields":{},"created":"2020-12-19T00:00:00Z","last_updated":"2020-12-19T02:43:53.309000Z","tenant_count":11,"_depth":0}]}'
+    headers:
+      Allow:
+      - GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS
+      Content-Language:
+      - en
+      Content-Length:
+      - '409'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - Unit/1.33.0
+      Vary:
+      - HX-Request, Accept-Language, Cookie, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/integration/fixtures/v41/tenancy_tenant_groups_01/expected.yaml
+++ b/tests/integration/fixtures/v41/tenancy_tenant_groups_01/expected.yaml
@@ -1,0 +1,30 @@
+# AUTO-GENERATED - DO NOT EDIT
+# This file is generated from definitions.yaml
+# To regenerate: python -m tests.integration.generate_fixtures
+
+definition:
+  id: tenancy_tenant_groups_01
+  method: tenancy_tenant_groups
+  args:
+    limit: 5
+call:
+  client_call: tenancy_tenant_groups
+  client_call_args: []
+  client_call_kwargs:
+    limit: 5
+output: !!python/object:annetbox.base.models.PagingResponse
+  next: null
+  previous: null
+  count: 1
+  results:
+  - !!python/object:annetbox.v41.models.TenantGroup
+    id: 1
+    name: Customers
+    display: Customers
+    url: http://localhost:8041/api/tenancy/tenant-groups/1/
+    slug: customers
+    description: ''
+    custom_fields: {}
+    created: 2020-12-19 00:00:00+00:00
+    last_updated: 2020-12-19 02:43:53.309000+00:00
+    parent: null

--- a/tests/integration/fixtures/v42/circuit_dark_fiber_01/cassette.yaml
+++ b/tests/integration/fixtures/v42/circuit_dark_fiber_01/cassette.yaml
@@ -8,8 +8,6 @@ interactions:
       - gzip, deflate, zstd
       Connection:
       - keep-alive
-      User-Agent:
-      - python-requests/2.33.1
     method: GET
     uri: http://localhost:8042/api/circuits/circuits/?limit=1&offset=0&type=dark-fiber
   response:
@@ -55,8 +53,6 @@ interactions:
       - gzip, deflate, zstd
       Connection:
       - keep-alive
-      User-Agent:
-      - python-requests/2.33.1
     method: GET
     uri: http://localhost:8042/api/circuits/circuits/30/
   response:

--- a/tests/integration/fixtures/v42/circuit_internet_01/cassette.yaml
+++ b/tests/integration/fixtures/v42/circuit_internet_01/cassette.yaml
@@ -8,8 +8,6 @@ interactions:
       - gzip, deflate, zstd
       Connection:
       - keep-alive
-      User-Agent:
-      - python-requests/2.33.1
     method: GET
     uri: http://localhost:8042/api/circuits/circuits/?limit=1&offset=0&type=internet
   response:
@@ -51,8 +49,6 @@ interactions:
       - gzip, deflate, zstd
       Connection:
       - keep-alive
-      User-Agent:
-      - python-requests/2.33.1
     method: GET
     uri: http://localhost:8042/api/circuits/circuits/19/
   response:

--- a/tests/integration/fixtures/v42/circuit_mpls_01/cassette.yaml
+++ b/tests/integration/fixtures/v42/circuit_mpls_01/cassette.yaml
@@ -8,8 +8,6 @@ interactions:
       - gzip, deflate, zstd
       Connection:
       - keep-alive
-      User-Agent:
-      - python-requests/2.33.1
     method: GET
     uri: http://localhost:8042/api/circuits/circuits/?limit=1&offset=0&type=mpls
   response:
@@ -53,8 +51,6 @@ interactions:
       - gzip, deflate, zstd
       Connection:
       - keep-alive
-      User-Agent:
-      - python-requests/2.33.1
     method: GET
     uri: http://localhost:8042/api/circuits/circuits/14/
   response:

--- a/tests/integration/fixtures/v42/circuits_dark_fiber_01/cassette.yaml
+++ b/tests/integration/fixtures/v42/circuits_dark_fiber_01/cassette.yaml
@@ -8,8 +8,6 @@ interactions:
       - gzip, deflate, zstd
       Connection:
       - keep-alive
-      User-Agent:
-      - python-requests/2.33.1
     method: GET
     uri: http://localhost:8042/api/circuits/circuits/?limit=20&offset=0&type=dark-fiber
   response:

--- a/tests/integration/fixtures/v42/circuits_internet_01/cassette.yaml
+++ b/tests/integration/fixtures/v42/circuits_internet_01/cassette.yaml
@@ -8,8 +8,6 @@ interactions:
       - gzip, deflate, zstd
       Connection:
       - keep-alive
-      User-Agent:
-      - python-requests/2.33.1
     method: GET
     uri: http://localhost:8042/api/circuits/circuits/?limit=20&offset=0&type=internet
   response:

--- a/tests/integration/fixtures/v42/circuits_mpls_01/cassette.yaml
+++ b/tests/integration/fixtures/v42/circuits_mpls_01/cassette.yaml
@@ -8,8 +8,6 @@ interactions:
       - gzip, deflate, zstd
       Connection:
       - keep-alive
-      User-Agent:
-      - python-requests/2.33.1
     method: GET
     uri: http://localhost:8042/api/circuits/circuits/?limit=20&offset=0&type=mpls
   response:

--- a/tests/integration/fixtures/v42/dcim_all_devices_01/cassette.yaml
+++ b/tests/integration/fixtures/v42/dcim_all_devices_01/cassette.yaml
@@ -8,8 +8,6 @@ interactions:
       - gzip, deflate, zstd
       Connection:
       - keep-alive
-      User-Agent:
-      - python-requests/2.33.1
     method: GET
     uri: http://localhost:8042/api/dcim/devices/?limit=30&offset=0
   response:

--- a/tests/integration/fixtures/v42/dcim_all_interfaces_01/cassette.yaml
+++ b/tests/integration/fixtures/v42/dcim_all_interfaces_01/cassette.yaml
@@ -8,8 +8,6 @@ interactions:
       - gzip, deflate, zstd
       Connection:
       - keep-alive
-      User-Agent:
-      - python-requests/2.33.1
     method: GET
     uri: http://localhost:8042/api/dcim/interfaces/?device_id=1&device_id=2&device_id=3&device_id=4&device_id=5&device_id=6&device_id=7&device_id=8&device_id=9&device_id=10&limit=100&offset=0
   response:
@@ -173,8 +171,6 @@ interactions:
       - gzip, deflate, zstd
       Connection:
       - keep-alive
-      User-Agent:
-      - python-requests/2.33.1
     method: GET
     uri: http://localhost:8042/api/dcim/interfaces/?device_id=1&device_id=2&device_id=3&device_id=4&device_id=5&device_id=6&device_id=7&device_id=8&device_id=9&device_id=10&limit=100&offset=100
   response:
@@ -258,8 +254,6 @@ interactions:
       - gzip, deflate, zstd
       Connection:
       - keep-alive
-      User-Agent:
-      - python-requests/2.33.1
     method: GET
     uri: http://localhost:8042/api/dcim/interfaces/?device_id=11&device_id=12&device_id=13&limit=100&offset=0
   response:

--- a/tests/integration/fixtures/v42/dcim_cables_01/cassette.yaml
+++ b/tests/integration/fixtures/v42/dcim_cables_01/cassette.yaml
@@ -8,8 +8,6 @@ interactions:
       - gzip, deflate, zstd
       Connection:
       - keep-alive
-      User-Agent:
-      - python-requests/2.33.1
     method: GET
     uri: http://localhost:8042/api/dcim/cables/?limit=5&offset=0
   response:

--- a/tests/integration/fixtures/v42/dcim_console_port_01/cassette.yaml
+++ b/tests/integration/fixtures/v42/dcim_console_port_01/cassette.yaml
@@ -8,8 +8,6 @@ interactions:
       - gzip, deflate, zstd
       Connection:
       - keep-alive
-      User-Agent:
-      - python-requests/2.33.1
     method: GET
     uri: http://localhost:8042/api/dcim/console-ports/?limit=5&offset=0
   response:
@@ -56,8 +54,6 @@ interactions:
       - gzip, deflate, zstd
       Connection:
       - keep-alive
-      User-Agent:
-      - python-requests/2.33.1
     method: GET
     uri: http://localhost:8042/api/dcim/console-ports/1/
   response:

--- a/tests/integration/fixtures/v42/dcim_console_ports_01/cassette.yaml
+++ b/tests/integration/fixtures/v42/dcim_console_ports_01/cassette.yaml
@@ -8,8 +8,6 @@ interactions:
       - gzip, deflate, zstd
       Connection:
       - keep-alive
-      User-Agent:
-      - python-requests/2.33.1
     method: GET
     uri: http://localhost:8042/api/dcim/console-ports/?limit=5&offset=0
   response:

--- a/tests/integration/fixtures/v42/dcim_device_01/cassette.yaml
+++ b/tests/integration/fixtures/v42/dcim_device_01/cassette.yaml
@@ -8,8 +8,6 @@ interactions:
       - gzip, deflate, zstd
       Connection:
       - keep-alive
-      User-Agent:
-      - python-requests/2.33.1
     method: GET
     uri: http://localhost:8042/api/dcim/devices/?limit=10&offset=0
   response:
@@ -80,8 +78,6 @@ interactions:
       - gzip, deflate, zstd
       Connection:
       - keep-alive
-      User-Agent:
-      - python-requests/2.33.1
     method: GET
     uri: http://localhost:8042/api/dcim/devices/27/
   response:

--- a/tests/integration/fixtures/v42/dcim_devices_01/cassette.yaml
+++ b/tests/integration/fixtures/v42/dcim_devices_01/cassette.yaml
@@ -8,8 +8,6 @@ interactions:
       - gzip, deflate, zstd
       Connection:
       - keep-alive
-      User-Agent:
-      - python-requests/2.33.1
     method: GET
     uri: http://localhost:8042/api/dcim/devices/?limit=10&offset=0
   response:

--- a/tests/integration/fixtures/v42/dcim_interface_trace_01/cassette.yaml
+++ b/tests/integration/fixtures/v42/dcim_interface_trace_01/cassette.yaml
@@ -8,8 +8,6 @@ interactions:
       - gzip, deflate, zstd
       Connection:
       - keep-alive
-      User-Agent:
-      - python-requests/2.33.1
     method: GET
     uri: http://localhost:8042/api/dcim/interfaces/28/trace/
   response:

--- a/tests/integration/fixtures/v42/dcim_interface_trace_02/cassette.yaml
+++ b/tests/integration/fixtures/v42/dcim_interface_trace_02/cassette.yaml
@@ -8,8 +8,6 @@ interactions:
       - gzip, deflate, zstd
       Connection:
       - keep-alive
-      User-Agent:
-      - python-requests/2.33.1
     method: GET
     uri: http://localhost:8042/api/dcim/interfaces/157/trace/
   response:

--- a/tests/integration/fixtures/v42/dcim_interface_trace_03/cassette.yaml
+++ b/tests/integration/fixtures/v42/dcim_interface_trace_03/cassette.yaml
@@ -8,8 +8,6 @@ interactions:
       - gzip, deflate, zstd
       Connection:
       - keep-alive
-      User-Agent:
-      - python-requests/2.33.1
     method: GET
     uri: http://localhost:8042/api/dcim/interfaces/969/trace/
   response:

--- a/tests/integration/fixtures/v42/dcim_location_01/cassette.yaml
+++ b/tests/integration/fixtures/v42/dcim_location_01/cassette.yaml
@@ -1,0 +1,88 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+    method: GET
+    uri: http://localhost:8042/api/dcim/locations/?limit=5&offset=0
+  response:
+    body:
+      string: '{"count":4,"next":null,"previous":null,"results":[{"id":1,"url":"http://localhost:8042/api/dcim/locations/1/","display_url":"http://localhost:8042/dcim/locations/1/","display":"Row
+        1","name":"Row 1","slug":"row-1","site":{"id":21,"url":"http://localhost:8042/api/dcim/sites/21/","display":"MDF","name":"MDF","slug":"ncsu-065","description":"Main
+        Distribution Frame"},"parent":null,"status":{"value":"active","label":"Active"},"tenant":null,"facility":"","description":"","tags":[],"custom_fields":{},"created":"2021-04-02T00:00:00Z","last_updated":"2021-04-02T16:57:17.398000Z","rack_count":8,"device_count":10,"prefix_count":0,"_depth":0},{"id":2,"url":"http://localhost:8042/api/dcim/locations/2/","display_url":"http://localhost:8042/dcim/locations/2/","display":"Row
+        2","name":"Row 2","slug":"row-2","site":{"id":21,"url":"http://localhost:8042/api/dcim/sites/21/","display":"MDF","name":"MDF","slug":"ncsu-065","description":"Main
+        Distribution Frame"},"parent":null,"status":{"value":"active","label":"Active"},"tenant":null,"facility":"","description":"","tags":[],"custom_fields":{},"created":"2021-04-02T00:00:00Z","last_updated":"2021-04-02T16:57:24.629000Z","rack_count":8,"device_count":1,"prefix_count":0,"_depth":0},{"id":3,"url":"http://localhost:8042/api/dcim/locations/3/","display_url":"http://localhost:8042/dcim/locations/3/","display":"Row
+        3","name":"Row 3","slug":"row-3","site":{"id":21,"url":"http://localhost:8042/api/dcim/sites/21/","display":"MDF","name":"MDF","slug":"ncsu-065","description":"Main
+        Distribution Frame"},"parent":null,"status":{"value":"active","label":"Active"},"tenant":null,"facility":"","description":"","tags":[],"custom_fields":{},"created":"2021-04-02T00:00:00Z","last_updated":"2021-04-02T16:57:31.713000Z","rack_count":8,"device_count":0,"prefix_count":0,"_depth":0},{"id":4,"url":"http://localhost:8042/api/dcim/locations/4/","display_url":"http://localhost:8042/dcim/locations/4/","display":"Row
+        4","name":"Row 4","slug":"row-4","site":{"id":21,"url":"http://localhost:8042/api/dcim/sites/21/","display":"MDF","name":"MDF","slug":"ncsu-065","description":"Main
+        Distribution Frame"},"parent":null,"status":{"value":"active","label":"Active"},"tenant":null,"facility":"","description":"","tags":[],"custom_fields":{},"created":"2021-04-02T00:00:00Z","last_updated":"2021-04-02T16:57:37.732000Z","rack_count":0,"device_count":0,"prefix_count":0,"_depth":0}]}'
+    headers:
+      Allow:
+      - GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS
+      Content-Language:
+      - en
+      Content-Length:
+      - '2408'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - Unit/1.34.1
+      Vary:
+      - HX-Request, Accept-Language, Cookie, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+    method: GET
+    uri: http://localhost:8042/api/dcim/locations/1/
+  response:
+    body:
+      string: '{"id":1,"url":"http://localhost:8042/api/dcim/locations/1/","display_url":"http://localhost:8042/dcim/locations/1/","display":"Row
+        1","name":"Row 1","slug":"row-1","site":{"id":21,"url":"http://localhost:8042/api/dcim/sites/21/","display":"MDF","name":"MDF","slug":"ncsu-065","description":"Main
+        Distribution Frame"},"parent":null,"status":{"value":"active","label":"Active"},"tenant":null,"facility":"","description":"","tags":[],"custom_fields":{},"created":"2021-04-02T00:00:00Z","last_updated":"2021-04-02T16:57:17.398000Z","rack_count":8,"device_count":10,"prefix_count":0,"_depth":0}'
+    headers:
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      Content-Language:
+      - en
+      Content-Length:
+      - '589'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - Unit/1.34.1
+      Vary:
+      - HX-Request, Accept-Language, Cookie, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/integration/fixtures/v42/dcim_location_01/expected.yaml
+++ b/tests/integration/fixtures/v42/dcim_location_01/expected.yaml
@@ -1,0 +1,39 @@
+# AUTO-GENERATED - DO NOT EDIT
+# This file is generated from definitions.yaml
+# To regenerate: python -m tests.integration.generate_fixtures
+
+definition:
+  id: dcim_location_01
+  method: dcim_location
+  args:
+    location_id:
+      call: dcim_locations
+      args:
+        limit: 5
+      extract: results[0].id
+call:
+  client_call: dcim_location
+  client_call_args: []
+  client_call_kwargs:
+    location_id: 1
+output: !!python/object:annetbox.v42.models.Location
+  id: 1
+  name: Row 1
+  display: Row 1
+  url: http://localhost:8042/api/dcim/locations/1/
+  slug: row-1
+  site: !!python/object:annetbox.v42.models.Entity
+    id: 21
+    name: MDF
+    display: MDF
+    url: http://localhost:8042/api/dcim/sites/21/
+  status: !!python/object:annetbox.v42.models.Label
+    value: active
+    label: Active
+  description: ''
+  custom_fields: {}
+  created: 2021-04-02 00:00:00+00:00
+  last_updated: 2021-04-02 16:57:17.398000+00:00
+  parent: null
+  tenant: null
+  facility: ''

--- a/tests/integration/fixtures/v42/dcim_locations_01/cassette.yaml
+++ b/tests/integration/fixtures/v42/dcim_locations_01/cassette.yaml
@@ -1,0 +1,48 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+    method: GET
+    uri: http://localhost:8042/api/dcim/locations/?limit=5&offset=0
+  response:
+    body:
+      string: '{"count":4,"next":null,"previous":null,"results":[{"id":1,"url":"http://localhost:8042/api/dcim/locations/1/","display_url":"http://localhost:8042/dcim/locations/1/","display":"Row
+        1","name":"Row 1","slug":"row-1","site":{"id":21,"url":"http://localhost:8042/api/dcim/sites/21/","display":"MDF","name":"MDF","slug":"ncsu-065","description":"Main
+        Distribution Frame"},"parent":null,"status":{"value":"active","label":"Active"},"tenant":null,"facility":"","description":"","tags":[],"custom_fields":{},"created":"2021-04-02T00:00:00Z","last_updated":"2021-04-02T16:57:17.398000Z","rack_count":8,"device_count":10,"prefix_count":0,"_depth":0},{"id":2,"url":"http://localhost:8042/api/dcim/locations/2/","display_url":"http://localhost:8042/dcim/locations/2/","display":"Row
+        2","name":"Row 2","slug":"row-2","site":{"id":21,"url":"http://localhost:8042/api/dcim/sites/21/","display":"MDF","name":"MDF","slug":"ncsu-065","description":"Main
+        Distribution Frame"},"parent":null,"status":{"value":"active","label":"Active"},"tenant":null,"facility":"","description":"","tags":[],"custom_fields":{},"created":"2021-04-02T00:00:00Z","last_updated":"2021-04-02T16:57:24.629000Z","rack_count":8,"device_count":1,"prefix_count":0,"_depth":0},{"id":3,"url":"http://localhost:8042/api/dcim/locations/3/","display_url":"http://localhost:8042/dcim/locations/3/","display":"Row
+        3","name":"Row 3","slug":"row-3","site":{"id":21,"url":"http://localhost:8042/api/dcim/sites/21/","display":"MDF","name":"MDF","slug":"ncsu-065","description":"Main
+        Distribution Frame"},"parent":null,"status":{"value":"active","label":"Active"},"tenant":null,"facility":"","description":"","tags":[],"custom_fields":{},"created":"2021-04-02T00:00:00Z","last_updated":"2021-04-02T16:57:31.713000Z","rack_count":8,"device_count":0,"prefix_count":0,"_depth":0},{"id":4,"url":"http://localhost:8042/api/dcim/locations/4/","display_url":"http://localhost:8042/dcim/locations/4/","display":"Row
+        4","name":"Row 4","slug":"row-4","site":{"id":21,"url":"http://localhost:8042/api/dcim/sites/21/","display":"MDF","name":"MDF","slug":"ncsu-065","description":"Main
+        Distribution Frame"},"parent":null,"status":{"value":"active","label":"Active"},"tenant":null,"facility":"","description":"","tags":[],"custom_fields":{},"created":"2021-04-02T00:00:00Z","last_updated":"2021-04-02T16:57:37.732000Z","rack_count":0,"device_count":0,"prefix_count":0,"_depth":0}]}'
+    headers:
+      Allow:
+      - GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS
+      Content-Language:
+      - en
+      Content-Length:
+      - '2408'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - Unit/1.34.1
+      Vary:
+      - HX-Request, Accept-Language, Cookie, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/integration/fixtures/v42/dcim_locations_01/expected.yaml
+++ b/tests/integration/fixtures/v42/dcim_locations_01/expected.yaml
@@ -1,0 +1,103 @@
+# AUTO-GENERATED - DO NOT EDIT
+# This file is generated from definitions.yaml
+# To regenerate: python -m tests.integration.generate_fixtures
+
+definition:
+  id: dcim_locations_01
+  method: dcim_locations
+  args:
+    limit: 5
+call:
+  client_call: dcim_locations
+  client_call_args: []
+  client_call_kwargs:
+    limit: 5
+output: !!python/object:annetbox.base.models.PagingResponse
+  next: null
+  previous: null
+  count: 4
+  results:
+  - !!python/object:annetbox.v42.models.Location
+    id: 1
+    name: Row 1
+    display: Row 1
+    url: http://localhost:8042/api/dcim/locations/1/
+    slug: row-1
+    site: !!python/object:annetbox.v42.models.Entity
+      id: 21
+      name: MDF
+      display: MDF
+      url: http://localhost:8042/api/dcim/sites/21/
+    status: !!python/object:annetbox.v42.models.Label
+      value: active
+      label: Active
+    description: ''
+    custom_fields: {}
+    created: 2021-04-02 00:00:00+00:00
+    last_updated: 2021-04-02 16:57:17.398000+00:00
+    parent: null
+    tenant: null
+    facility: ''
+  - !!python/object:annetbox.v42.models.Location
+    id: 2
+    name: Row 2
+    display: Row 2
+    url: http://localhost:8042/api/dcim/locations/2/
+    slug: row-2
+    site: !!python/object:annetbox.v42.models.Entity
+      id: 21
+      name: MDF
+      display: MDF
+      url: http://localhost:8042/api/dcim/sites/21/
+    status: !!python/object:annetbox.v42.models.Label
+      value: active
+      label: Active
+    description: ''
+    custom_fields: {}
+    created: 2021-04-02 00:00:00+00:00
+    last_updated: 2021-04-02 16:57:24.629000+00:00
+    parent: null
+    tenant: null
+    facility: ''
+  - !!python/object:annetbox.v42.models.Location
+    id: 3
+    name: Row 3
+    display: Row 3
+    url: http://localhost:8042/api/dcim/locations/3/
+    slug: row-3
+    site: !!python/object:annetbox.v42.models.Entity
+      id: 21
+      name: MDF
+      display: MDF
+      url: http://localhost:8042/api/dcim/sites/21/
+    status: !!python/object:annetbox.v42.models.Label
+      value: active
+      label: Active
+    description: ''
+    custom_fields: {}
+    created: 2021-04-02 00:00:00+00:00
+    last_updated: 2021-04-02 16:57:31.713000+00:00
+    parent: null
+    tenant: null
+    facility: ''
+  - !!python/object:annetbox.v42.models.Location
+    id: 4
+    name: Row 4
+    display: Row 4
+    url: http://localhost:8042/api/dcim/locations/4/
+    slug: row-4
+    site: !!python/object:annetbox.v42.models.Entity
+      id: 21
+      name: MDF
+      display: MDF
+      url: http://localhost:8042/api/dcim/sites/21/
+    status: !!python/object:annetbox.v42.models.Label
+      value: active
+      label: Active
+    description: ''
+    custom_fields: {}
+    created: 2021-04-02 00:00:00+00:00
+    last_updated: 2021-04-02 16:57:37.732000+00:00
+    parent: null
+    tenant: null
+    facility: ''

--- a/tests/integration/fixtures/v42/dcim_region_01/cassette.yaml
+++ b/tests/integration/fixtures/v42/dcim_region_01/cassette.yaml
@@ -1,0 +1,78 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+    method: GET
+    uri: http://localhost:8042/api/dcim/regions/?limit=5&offset=0
+  response:
+    body:
+      string: '{"count":67,"next":"http://localhost:8042/api/dcim/regions/?limit=5&offset=5","previous":null,"results":[{"id":4,"url":"http://localhost:8042/api/dcim/regions/4/","display_url":"http://localhost:8042/dcim/regions/4/","display":"Africa","name":"Africa","slug":"africa","parent":null,"description":"","tags":[],"custom_fields":{},"created":"2020-12-18T00:00:00Z","last_updated":"2020-12-18T02:10:30.332000Z","site_count":0,"prefix_count":0,"_depth":0},{"id":5,"url":"http://localhost:8042/api/dcim/regions/5/","display_url":"http://localhost:8042/dcim/regions/5/","display":"Asia","name":"Asia","slug":"asia","parent":null,"description":"","tags":[],"custom_fields":{},"created":"2020-12-18T00:00:00Z","last_updated":"2020-12-18T02:10:30.367000Z","site_count":0,"prefix_count":0,"_depth":0},{"id":15,"url":"http://localhost:8042/api/dcim/regions/15/","display_url":"http://localhost:8042/dcim/regions/15/","display":"China","name":"China","slug":"cn","parent":{"id":5,"url":"http://localhost:8042/api/dcim/regions/5/","display_url":"http://localhost:8042/dcim/regions/5/","display":"Asia","name":"Asia","slug":"asia","_depth":0},"description":"","tags":[],"custom_fields":{},"created":"2020-12-18T00:00:00Z","last_updated":"2020-12-18T02:17:11.368000Z","site_count":0,"prefix_count":0,"_depth":1},{"id":16,"url":"http://localhost:8042/api/dcim/regions/16/","display_url":"http://localhost:8042/dcim/regions/16/","display":"India","name":"India","slug":"in","parent":{"id":5,"url":"http://localhost:8042/api/dcim/regions/5/","display_url":"http://localhost:8042/dcim/regions/5/","display":"Asia","name":"Asia","slug":"asia","_depth":0},"description":"","tags":[],"custom_fields":{},"created":"2020-12-18T00:00:00Z","last_updated":"2020-12-18T02:17:11.423000Z","site_count":0,"prefix_count":0,"_depth":1},{"id":14,"url":"http://localhost:8042/api/dcim/regions/14/","display_url":"http://localhost:8042/dcim/regions/14/","display":"Singapore","name":"Singapore","slug":"sg","parent":{"id":5,"url":"http://localhost:8042/api/dcim/regions/5/","display_url":"http://localhost:8042/dcim/regions/5/","display":"Asia","name":"Asia","slug":"asia","_depth":0},"description":"","tags":[],"custom_fields":{},"created":"2020-12-18T00:00:00Z","last_updated":"2020-12-18T02:17:11.318000Z","site_count":0,"prefix_count":0,"_depth":1}]}'
+    headers:
+      Allow:
+      - GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS
+      Content-Language:
+      - en
+      Content-Length:
+      - '2316'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - Unit/1.34.1
+      Vary:
+      - HX-Request, Accept-Language, Cookie, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+    method: GET
+    uri: http://localhost:8042/api/dcim/regions/4/
+  response:
+    body:
+      string: '{"id":4,"url":"http://localhost:8042/api/dcim/regions/4/","display_url":"http://localhost:8042/dcim/regions/4/","display":"Africa","name":"Africa","slug":"africa","parent":null,"description":"","tags":[],"custom_fields":{},"created":"2020-12-18T00:00:00Z","last_updated":"2020-12-18T02:10:30.332000Z","site_count":0,"prefix_count":0,"_depth":0}'
+    headers:
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      Content-Language:
+      - en
+      Content-Length:
+      - '344'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - Unit/1.34.1
+      Vary:
+      - HX-Request, Accept-Language, Cookie, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/integration/fixtures/v42/dcim_region_01/expected.yaml
+++ b/tests/integration/fixtures/v42/dcim_region_01/expected.yaml
@@ -1,0 +1,29 @@
+# AUTO-GENERATED - DO NOT EDIT
+# This file is generated from definitions.yaml
+# To regenerate: python -m tests.integration.generate_fixtures
+
+definition:
+  id: dcim_region_01
+  method: dcim_region
+  args:
+    region_id:
+      call: dcim_regions
+      args:
+        limit: 5
+      extract: results[0].id
+call:
+  client_call: dcim_region
+  client_call_args: []
+  client_call_kwargs:
+    region_id: 4
+output: !!python/object:annetbox.v42.models.Region
+  id: 4
+  name: Africa
+  display: Africa
+  url: http://localhost:8042/api/dcim/regions/4/
+  slug: africa
+  description: ''
+  custom_fields: {}
+  created: 2020-12-18 00:00:00+00:00
+  last_updated: 2020-12-18 02:10:30.332000+00:00
+  parent: null

--- a/tests/integration/fixtures/v42/dcim_regions_01/cassette.yaml
+++ b/tests/integration/fixtures/v42/dcim_regions_01/cassette.yaml
@@ -1,0 +1,40 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+    method: GET
+    uri: http://localhost:8042/api/dcim/regions/?limit=5&offset=0
+  response:
+    body:
+      string: '{"count":67,"next":"http://localhost:8042/api/dcim/regions/?limit=5&offset=5","previous":null,"results":[{"id":4,"url":"http://localhost:8042/api/dcim/regions/4/","display_url":"http://localhost:8042/dcim/regions/4/","display":"Africa","name":"Africa","slug":"africa","parent":null,"description":"","tags":[],"custom_fields":{},"created":"2020-12-18T00:00:00Z","last_updated":"2020-12-18T02:10:30.332000Z","site_count":0,"prefix_count":0,"_depth":0},{"id":5,"url":"http://localhost:8042/api/dcim/regions/5/","display_url":"http://localhost:8042/dcim/regions/5/","display":"Asia","name":"Asia","slug":"asia","parent":null,"description":"","tags":[],"custom_fields":{},"created":"2020-12-18T00:00:00Z","last_updated":"2020-12-18T02:10:30.367000Z","site_count":0,"prefix_count":0,"_depth":0},{"id":15,"url":"http://localhost:8042/api/dcim/regions/15/","display_url":"http://localhost:8042/dcim/regions/15/","display":"China","name":"China","slug":"cn","parent":{"id":5,"url":"http://localhost:8042/api/dcim/regions/5/","display_url":"http://localhost:8042/dcim/regions/5/","display":"Asia","name":"Asia","slug":"asia","_depth":0},"description":"","tags":[],"custom_fields":{},"created":"2020-12-18T00:00:00Z","last_updated":"2020-12-18T02:17:11.368000Z","site_count":0,"prefix_count":0,"_depth":1},{"id":16,"url":"http://localhost:8042/api/dcim/regions/16/","display_url":"http://localhost:8042/dcim/regions/16/","display":"India","name":"India","slug":"in","parent":{"id":5,"url":"http://localhost:8042/api/dcim/regions/5/","display_url":"http://localhost:8042/dcim/regions/5/","display":"Asia","name":"Asia","slug":"asia","_depth":0},"description":"","tags":[],"custom_fields":{},"created":"2020-12-18T00:00:00Z","last_updated":"2020-12-18T02:17:11.423000Z","site_count":0,"prefix_count":0,"_depth":1},{"id":14,"url":"http://localhost:8042/api/dcim/regions/14/","display_url":"http://localhost:8042/dcim/regions/14/","display":"Singapore","name":"Singapore","slug":"sg","parent":{"id":5,"url":"http://localhost:8042/api/dcim/regions/5/","display_url":"http://localhost:8042/dcim/regions/5/","display":"Asia","name":"Asia","slug":"asia","_depth":0},"description":"","tags":[],"custom_fields":{},"created":"2020-12-18T00:00:00Z","last_updated":"2020-12-18T02:17:11.318000Z","site_count":0,"prefix_count":0,"_depth":1}]}'
+    headers:
+      Allow:
+      - GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS
+      Content-Language:
+      - en
+      Content-Length:
+      - '2316'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - Unit/1.34.1
+      Vary:
+      - HX-Request, Accept-Language, Cookie, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/integration/fixtures/v42/dcim_regions_01/expected.yaml
+++ b/tests/integration/fixtures/v42/dcim_regions_01/expected.yaml
@@ -1,0 +1,89 @@
+# AUTO-GENERATED - DO NOT EDIT
+# This file is generated from definitions.yaml
+# To regenerate: python -m tests.integration.generate_fixtures
+
+definition:
+  id: dcim_regions_01
+  method: dcim_regions
+  args:
+    limit: 5
+call:
+  client_call: dcim_regions
+  client_call_args: []
+  client_call_kwargs:
+    limit: 5
+output: !!python/object:annetbox.base.models.PagingResponse
+  next: http://localhost:8042/api/dcim/regions/?limit=5&offset=5
+  previous: null
+  count: 67
+  results:
+  - !!python/object:annetbox.v42.models.Region
+    id: 4
+    name: Africa
+    display: Africa
+    url: http://localhost:8042/api/dcim/regions/4/
+    slug: africa
+    description: ''
+    custom_fields: {}
+    created: 2020-12-18 00:00:00+00:00
+    last_updated: 2020-12-18 02:10:30.332000+00:00
+    parent: null
+  - !!python/object:annetbox.v42.models.Region
+    id: 5
+    name: Asia
+    display: Asia
+    url: http://localhost:8042/api/dcim/regions/5/
+    slug: asia
+    description: ''
+    custom_fields: {}
+    created: 2020-12-18 00:00:00+00:00
+    last_updated: 2020-12-18 02:10:30.367000+00:00
+    parent: null
+  - !!python/object:annetbox.v42.models.Region
+    id: 15
+    name: China
+    display: China
+    url: http://localhost:8042/api/dcim/regions/15/
+    slug: cn
+    description: ''
+    custom_fields: {}
+    created: 2020-12-18 00:00:00+00:00
+    last_updated: 2020-12-18 02:17:11.368000+00:00
+    parent: !!python/object:annetbox.v42.models.EntityWithSlug
+      id: 5
+      name: Asia
+      display: Asia
+      url: http://localhost:8042/api/dcim/regions/5/
+      slug: asia
+  - !!python/object:annetbox.v42.models.Region
+    id: 16
+    name: India
+    display: India
+    url: http://localhost:8042/api/dcim/regions/16/
+    slug: in
+    description: ''
+    custom_fields: {}
+    created: 2020-12-18 00:00:00+00:00
+    last_updated: 2020-12-18 02:17:11.423000+00:00
+    parent: !!python/object:annetbox.v42.models.EntityWithSlug
+      id: 5
+      name: Asia
+      display: Asia
+      url: http://localhost:8042/api/dcim/regions/5/
+      slug: asia
+  - !!python/object:annetbox.v42.models.Region
+    id: 14
+    name: Singapore
+    display: Singapore
+    url: http://localhost:8042/api/dcim/regions/14/
+    slug: sg
+    description: ''
+    custom_fields: {}
+    created: 2020-12-18 00:00:00+00:00
+    last_updated: 2020-12-18 02:17:11.318000+00:00
+    parent: !!python/object:annetbox.v42.models.EntityWithSlug
+      id: 5
+      name: Asia
+      display: Asia
+      url: http://localhost:8042/api/dcim/regions/5/
+      slug: asia

--- a/tests/integration/fixtures/v42/dcim_site_01/cassette.yaml
+++ b/tests/integration/fixtures/v42/dcim_site_01/cassette.yaml
@@ -8,8 +8,6 @@ interactions:
       - gzip, deflate, zstd
       Connection:
       - keep-alive
-      User-Agent:
-      - python-requests/2.33.1
     method: GET
     uri: http://localhost:8042/api/dcim/sites/?limit=5&offset=0
   response:
@@ -64,8 +62,6 @@ interactions:
       - gzip, deflate, zstd
       Connection:
       - keep-alive
-      User-Agent:
-      - python-requests/2.33.1
     method: GET
     uri: http://localhost:8042/api/dcim/sites/24/
   response:

--- a/tests/integration/fixtures/v42/dcim_site_group_01/cassette.yaml
+++ b/tests/integration/fixtures/v42/dcim_site_group_01/cassette.yaml
@@ -1,0 +1,83 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+    method: GET
+    uri: http://localhost:8042/api/dcim/site-groups/?limit=5&offset=0
+  response:
+    body:
+      string: '{"count":3,"next":null,"previous":null,"results":[{"id":1,"url":"http://localhost:8042/api/dcim/site-groups/1/","display_url":"http://localhost:8042/dcim/site-groups/1/","display":"Customer
+        Sites","name":"Customer Sites","slug":"customer-sites","parent":null,"description":"","tags":[],"custom_fields":{},"created":"2021-12-30T00:00:00Z","last_updated":"2021-12-30T15:41:01.816000Z","site_count":20,"prefix_count":0,"_depth":0},{"id":2,"url":"http://localhost:8042/api/dcim/site-groups/2/","display_url":"http://localhost:8042/dcim/site-groups/2/","display":"Branch
+        Offices","name":"Branch Offices","slug":"branch-offices","parent":{"id":1,"url":"http://localhost:8042/api/dcim/site-groups/1/","display_url":"http://localhost:8042/dcim/site-groups/1/","display":"Customer
+        Sites","name":"Customer Sites","slug":"customer-sites","_depth":0},"description":"","tags":[],"custom_fields":{},"created":"2021-12-30T00:00:00Z","last_updated":"2021-12-30T15:41:13.892000Z","site_count":19,"prefix_count":65,"_depth":1},{"id":3,"url":"http://localhost:8042/api/dcim/site-groups/3/","display_url":"http://localhost:8042/dcim/site-groups/3/","display":"Headquarters","name":"Headquarters","slug":"headquarters","parent":{"id":1,"url":"http://localhost:8042/api/dcim/site-groups/1/","display_url":"http://localhost:8042/dcim/site-groups/1/","display":"Customer
+        Sites","name":"Customer Sites","slug":"customer-sites","_depth":0},"description":"","tags":[],"custom_fields":{},"created":"2021-12-30T00:00:00Z","last_updated":"2021-12-30T15:41:22.089000Z","site_count":1,"prefix_count":0,"_depth":1}]}'
+    headers:
+      Allow:
+      - GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS
+      Content-Language:
+      - en
+      Content-Length:
+      - '1583'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - Unit/1.34.1
+      Vary:
+      - HX-Request, Accept-Language, Cookie, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+    method: GET
+    uri: http://localhost:8042/api/dcim/site-groups/1/
+  response:
+    body:
+      string: '{"id":1,"url":"http://localhost:8042/api/dcim/site-groups/1/","display_url":"http://localhost:8042/dcim/site-groups/1/","display":"Customer
+        Sites","name":"Customer Sites","slug":"customer-sites","parent":null,"description":"","tags":[],"custom_fields":{},"created":"2021-12-30T00:00:00Z","last_updated":"2021-12-30T15:41:01.816000Z","site_count":20,"prefix_count":0,"_depth":0}'
+    headers:
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      Content-Language:
+      - en
+      Content-Length:
+      - '377'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - Unit/1.34.1
+      Vary:
+      - HX-Request, Accept-Language, Cookie, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/integration/fixtures/v42/dcim_site_group_01/expected.yaml
+++ b/tests/integration/fixtures/v42/dcim_site_group_01/expected.yaml
@@ -1,0 +1,29 @@
+# AUTO-GENERATED - DO NOT EDIT
+# This file is generated from definitions.yaml
+# To regenerate: python -m tests.integration.generate_fixtures
+
+definition:
+  id: dcim_site_group_01
+  method: dcim_site_group
+  args:
+    site_group_id:
+      call: dcim_site_groups
+      args:
+        limit: 5
+      extract: results[0].id
+call:
+  client_call: dcim_site_group
+  client_call_args: []
+  client_call_kwargs:
+    site_group_id: 1
+output: !!python/object:annetbox.v42.models.SiteGroup
+  id: 1
+  name: Customer Sites
+  display: Customer Sites
+  url: http://localhost:8042/api/dcim/site-groups/1/
+  slug: customer-sites
+  description: ''
+  custom_fields: {}
+  created: 2021-12-30 00:00:00+00:00
+  last_updated: 2021-12-30 15:41:01.816000+00:00
+  parent: null

--- a/tests/integration/fixtures/v42/dcim_site_groups_01/cassette.yaml
+++ b/tests/integration/fixtures/v42/dcim_site_groups_01/cassette.yaml
@@ -1,0 +1,44 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+    method: GET
+    uri: http://localhost:8042/api/dcim/site-groups/?limit=5&offset=0
+  response:
+    body:
+      string: '{"count":3,"next":null,"previous":null,"results":[{"id":1,"url":"http://localhost:8042/api/dcim/site-groups/1/","display_url":"http://localhost:8042/dcim/site-groups/1/","display":"Customer
+        Sites","name":"Customer Sites","slug":"customer-sites","parent":null,"description":"","tags":[],"custom_fields":{},"created":"2021-12-30T00:00:00Z","last_updated":"2021-12-30T15:41:01.816000Z","site_count":20,"prefix_count":0,"_depth":0},{"id":2,"url":"http://localhost:8042/api/dcim/site-groups/2/","display_url":"http://localhost:8042/dcim/site-groups/2/","display":"Branch
+        Offices","name":"Branch Offices","slug":"branch-offices","parent":{"id":1,"url":"http://localhost:8042/api/dcim/site-groups/1/","display_url":"http://localhost:8042/dcim/site-groups/1/","display":"Customer
+        Sites","name":"Customer Sites","slug":"customer-sites","_depth":0},"description":"","tags":[],"custom_fields":{},"created":"2021-12-30T00:00:00Z","last_updated":"2021-12-30T15:41:13.892000Z","site_count":19,"prefix_count":65,"_depth":1},{"id":3,"url":"http://localhost:8042/api/dcim/site-groups/3/","display_url":"http://localhost:8042/dcim/site-groups/3/","display":"Headquarters","name":"Headquarters","slug":"headquarters","parent":{"id":1,"url":"http://localhost:8042/api/dcim/site-groups/1/","display_url":"http://localhost:8042/dcim/site-groups/1/","display":"Customer
+        Sites","name":"Customer Sites","slug":"customer-sites","_depth":0},"description":"","tags":[],"custom_fields":{},"created":"2021-12-30T00:00:00Z","last_updated":"2021-12-30T15:41:22.089000Z","site_count":1,"prefix_count":0,"_depth":1}]}'
+    headers:
+      Allow:
+      - GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS
+      Content-Language:
+      - en
+      Content-Length:
+      - '1583'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - Unit/1.34.1
+      Vary:
+      - HX-Request, Accept-Language, Cookie, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/integration/fixtures/v42/dcim_site_groups_01/expected.yaml
+++ b/tests/integration/fixtures/v42/dcim_site_groups_01/expected.yaml
@@ -1,0 +1,62 @@
+# AUTO-GENERATED - DO NOT EDIT
+# This file is generated from definitions.yaml
+# To regenerate: python -m tests.integration.generate_fixtures
+
+definition:
+  id: dcim_site_groups_01
+  method: dcim_site_groups
+  args:
+    limit: 5
+call:
+  client_call: dcim_site_groups
+  client_call_args: []
+  client_call_kwargs:
+    limit: 5
+output: !!python/object:annetbox.base.models.PagingResponse
+  next: null
+  previous: null
+  count: 3
+  results:
+  - !!python/object:annetbox.v42.models.SiteGroup
+    id: 1
+    name: Customer Sites
+    display: Customer Sites
+    url: http://localhost:8042/api/dcim/site-groups/1/
+    slug: customer-sites
+    description: ''
+    custom_fields: {}
+    created: 2021-12-30 00:00:00+00:00
+    last_updated: 2021-12-30 15:41:01.816000+00:00
+    parent: null
+  - !!python/object:annetbox.v42.models.SiteGroup
+    id: 2
+    name: Branch Offices
+    display: Branch Offices
+    url: http://localhost:8042/api/dcim/site-groups/2/
+    slug: branch-offices
+    description: ''
+    custom_fields: {}
+    created: 2021-12-30 00:00:00+00:00
+    last_updated: 2021-12-30 15:41:13.892000+00:00
+    parent: !!python/object:annetbox.v42.models.EntityWithSlug
+      id: 1
+      name: Customer Sites
+      display: Customer Sites
+      url: http://localhost:8042/api/dcim/site-groups/1/
+      slug: customer-sites
+  - !!python/object:annetbox.v42.models.SiteGroup
+    id: 3
+    name: Headquarters
+    display: Headquarters
+    url: http://localhost:8042/api/dcim/site-groups/3/
+    slug: headquarters
+    description: ''
+    custom_fields: {}
+    created: 2021-12-30 00:00:00+00:00
+    last_updated: 2021-12-30 15:41:22.089000+00:00
+    parent: !!python/object:annetbox.v42.models.EntityWithSlug
+      id: 1
+      name: Customer Sites
+      display: Customer Sites
+      url: http://localhost:8042/api/dcim/site-groups/1/
+      slug: customer-sites

--- a/tests/integration/fixtures/v42/dcim_sites_01/cassette.yaml
+++ b/tests/integration/fixtures/v42/dcim_sites_01/cassette.yaml
@@ -8,8 +8,6 @@ interactions:
       - gzip, deflate, zstd
       Connection:
       - keep-alive
-      User-Agent:
-      - python-requests/2.33.1
     method: GET
     uri: http://localhost:8042/api/dcim/sites/?limit=5&offset=0
   response:

--- a/tests/integration/fixtures/v42/ipam_all_ip_addresses_01/cassette.yaml
+++ b/tests/integration/fixtures/v42/ipam_all_ip_addresses_01/cassette.yaml
@@ -8,8 +8,6 @@ interactions:
       - gzip, deflate, zstd
       Connection:
       - keep-alive
-      User-Agent:
-      - python-requests/2.33.1
     method: GET
     uri: http://localhost:8042/api/ipam/ip-addresses/?limit=50&offset=0
   response:

--- a/tests/integration/fixtures/v42/ipam_ip_address_01/cassette.yaml
+++ b/tests/integration/fixtures/v42/ipam_ip_address_01/cassette.yaml
@@ -8,8 +8,6 @@ interactions:
       - gzip, deflate, zstd
       Connection:
       - keep-alive
-      User-Agent:
-      - python-requests/2.33.1
     method: GET
     uri: http://localhost:8042/api/ipam/ip-addresses/?limit=10&offset=0
   response:
@@ -58,8 +56,6 @@ interactions:
       - gzip, deflate, zstd
       Connection:
       - keep-alive
-      User-Agent:
-      - python-requests/2.33.1
     method: GET
     uri: http://localhost:8042/api/ipam/ip-addresses/31/
   response:

--- a/tests/integration/fixtures/v42/ipam_ip_addresses_01/cassette.yaml
+++ b/tests/integration/fixtures/v42/ipam_ip_addresses_01/cassette.yaml
@@ -8,8 +8,6 @@ interactions:
       - gzip, deflate, zstd
       Connection:
       - keep-alive
-      User-Agent:
-      - python-requests/2.33.1
     method: GET
     uri: http://localhost:8042/api/ipam/ip-addresses/?limit=10&offset=0
   response:

--- a/tests/integration/fixtures/v42/ipam_vlans_01/cassette.yaml
+++ b/tests/integration/fixtures/v42/ipam_vlans_01/cassette.yaml
@@ -8,8 +8,6 @@ interactions:
       - gzip, deflate, zstd
       Connection:
       - keep-alive
-      User-Agent:
-      - python-requests/2.33.1
     method: GET
     uri: http://localhost:8042/api/ipam/vlans/?limit=10&offset=0
   response:

--- a/tests/integration/fixtures/v42/lock.yaml
+++ b/tests/integration/fixtures/v42/lock.yaml
@@ -99,12 +99,48 @@ test_cases:
     sha256: c28f9be996e207661e052078f82985d51b56b5f0307e35541f9ffbd3c0fc6deb
   - path: expected.yaml
     sha256: cb15c821321b0959d45f0e30d2ec16e776d02ea0e45f30cea99827aa5cebefba
+- test_case: dcim_location_01
+  files:
+  - path: cassette.yaml
+    sha256: 66e4ea1c77b0e0afc121bd4fc19b3d719d40f55992d71212310668708d014711
+  - path: expected.yaml
+    sha256: d61e90bb1de00091778c1ec7d417394e233d4044aa4394ca476ba7c612a15da8
+- test_case: dcim_locations_01
+  files:
+  - path: cassette.yaml
+    sha256: 7237d5f594cba4802d59cd22965dcfe0f3d61c5722c90db405950a929939e95b
+  - path: expected.yaml
+    sha256: 904da23548fafd90d0a9501c77726f262a76cc851266c9c14fa836daceae53b2
+- test_case: dcim_region_01
+  files:
+  - path: cassette.yaml
+    sha256: e3634b4dccfac93492535516eb212dc0e7a5c83eb2df4e891226ae75292ad4d2
+  - path: expected.yaml
+    sha256: 0dcbaba10140bdafcf49ec85aa74ad455f429e43ae35db0ae394e3c9f23a6a57
+- test_case: dcim_regions_01
+  files:
+  - path: cassette.yaml
+    sha256: ce9e67ec7de1a3fdd763e3d3b08d4a44e65c4e35388ec9578e0d9e5138ad8076
+  - path: expected.yaml
+    sha256: af7c4d6995d773605815b0d0e117001052e7f961a9efe1b7df5587b8cbcb21e6
 - test_case: dcim_site_01
   files:
   - path: cassette.yaml
     sha256: 56f849722861fb5a0f68c6b58d156e5e103f8beb084a369baf0873ad4346abe7
   - path: expected.yaml
     sha256: e957cb14ca8051ecd5562183fad1c114fe1dbbf2d07a2c62a7975552096fa7af
+- test_case: dcim_site_group_01
+  files:
+  - path: cassette.yaml
+    sha256: f380d5b23482f446bb1c23fb3e111fe46187883bc20fc1273eb67f0776f4aa7e
+  - path: expected.yaml
+    sha256: d75b164fb0a446b74303e40f74ec5c2922cb09739bbe5ece1d75c62407629d0e
+- test_case: dcim_site_groups_01
+  files:
+  - path: cassette.yaml
+    sha256: 4c610078473f98858e5f84646d5a309b3aa8b66dd7fa04fdd115dd70b14b56b5
+  - path: expected.yaml
+    sha256: 0cd773264a6e050a776121de3e4aad4a5ed4338595d25df5602b0df864b905f6
 - test_case: dcim_sites_01
   files:
   - path: cassette.yaml
@@ -135,4 +171,16 @@ test_cases:
     sha256: 66a794a37df3589c8fa252b0d0c29640c7903808eab8e95f79ab242a3764e8ec
   - path: expected.yaml
     sha256: 880e42c46cd1dff42ec6f389ad6c0b128b380d18371d11bf7e5e1871e1a44237
-sha256: 18959dfd38689bdbea80707969e7c387032a3f7214013a35a20be984008ee9d6
+- test_case: tenancy_tenant_group_01
+  files:
+  - path: cassette.yaml
+    sha256: 32ba6812709a794d51c9f5471f49443184a2e506c5d9dfdecef2572bf1b71bfd
+  - path: expected.yaml
+    sha256: 0c65dcae63ae90ae7252624be89209c8d99878decbdc87f9315d6aae3e734250
+- test_case: tenancy_tenant_groups_01
+  files:
+  - path: cassette.yaml
+    sha256: 8c691185c3df807b97db5cc77f11f457200250049c3261f331eb3740f62486bf
+  - path: expected.yaml
+    sha256: d73e31531eca5854ebae166b3b62c0d54353e02fe004fc107d5e3f4cd21e5957
+sha256: fb689874984d3a6e39f2a246596b61703c007be2cb0244502060f891600158da

--- a/tests/integration/fixtures/v42/lock.yaml
+++ b/tests/integration/fixtures/v42/lock.yaml
@@ -6,133 +6,133 @@ test_cases:
 - test_case: circuit_dark_fiber_01
   files:
   - path: cassette.yaml
-    sha256: 2c301daa0a78b7d4623a20a532dabd67cef01946e409fd221b5698126b8dd4f0
+    sha256: 5ed63e6ba606501ffc94fa88b249d6a4a03bb4de62c063e7f3cc0b5533601f42
   - path: expected.yaml
     sha256: 709bb1375f1e0d59c19c34eff077b4c73feaca26f2a093f0c2212851d1713894
 - test_case: circuit_internet_01
   files:
   - path: cassette.yaml
-    sha256: 1bcd71fad615bd81ca0b43d91a775f3f0e6a937079d0f9d4aabacacbd419804d
+    sha256: 1b3287ab90397ca8d5243978f9aa11fc7a9be33323ea5912de9a266e7e2095e8
   - path: expected.yaml
     sha256: 6b89f4ae6890d4194d92fb297c4d056c0e3ddb9b2ec178c47f56908408c878c0
 - test_case: circuit_mpls_01
   files:
   - path: cassette.yaml
-    sha256: 3ab63e54b52cafe9350e1058a8d4ec67a99a5656456c3549ce2ec07ceb72204f
+    sha256: bb449f6ca8dbdc20841ffa1cd562739b6ab5a103ce220392c398c19c5f0a3f63
   - path: expected.yaml
     sha256: de81ed1cd1b0b085a7447f1d52a6d71351489cb4151aa7ba0e1ef7daed8fc897
 - test_case: circuits_dark_fiber_01
   files:
   - path: cassette.yaml
-    sha256: b721ea4dbce76ffc0d5ebe4dd934c4fd54509581021c79b20b7552ee7a9da7eb
+    sha256: 4f3eb213f2748b4eb945bb6498911792e3af0d645b2e5997c104fd7507c45b3e
   - path: expected.yaml
     sha256: 89f03f09604793a21c13cd1aca5fa0ae69c304b1b873188878a9e57db9065759
 - test_case: circuits_internet_01
   files:
   - path: cassette.yaml
-    sha256: 98524220eaf704bb6e92c759b32cf0f1fe1ab9e752bcdc705609cc119f04d88d
+    sha256: 0594df0af8b3a31e3e9cf7c9c194bf28cc11fa522b6d2d1aee0ee63512529111
   - path: expected.yaml
     sha256: 6e1a6fa8680c5286fa6590dd1fccf182f5d5c6ef748b62ddcce643357801be6c
 - test_case: circuits_mpls_01
   files:
   - path: cassette.yaml
-    sha256: 8871f47b5f05c1a7a0139e11b9b181c4765ce53fcdfa404ddd1526fb315e7f91
+    sha256: 0b0af9f89d719c60efa4f322b50c60172769d5d555caf13e0422ff839a9a222a
   - path: expected.yaml
     sha256: 02808f42f871157ed235d84ee60fcb4c179298cbb300df5a37c1f8328a8bf79b
 - test_case: dcim_all_devices_01
   files:
   - path: cassette.yaml
-    sha256: f571b2f78b7a1795ff3306823c7185cd4ed3bf902643a0a8c5796fc97fa845fc
+    sha256: 64665de1f577d68b50d2f13e85217536c635537b8f0363fb9e72e6e3d1e957fd
   - path: expected.yaml
     sha256: a6e002644c1e69eb031ab710d25735690726c7b923ecd676bcf71ff016a0dff1
 - test_case: dcim_all_interfaces_01
   files:
   - path: cassette.yaml
-    sha256: 8e73a3ec898b6209765e42da3b569b8f673e9e9d3d5d1d0683155afbc34e52e4
+    sha256: 2c3f6a6fd71250f8d7eb783d82eb05a0efc4cca8d0576e196d8e636eb485e431
   - path: expected.yaml
     sha256: 1192daedfe7beebfc6bb2f8f5ec626b508853de415f5f7c339543dc1555a4bf3
 - test_case: dcim_cables_01
   files:
   - path: cassette.yaml
-    sha256: 9f4971f77f1bd95ea76392eaca1dd482884e3d0c1749cd7000185587db7972a4
+    sha256: b685bc8084e1b582312f5bf6292b710902c124dbec7efb5c9ded69b8bdf2d1b2
   - path: expected.yaml
     sha256: 8ebc8ebe383db378ba41c4376dc88b5b72a4f77a7fd8ca634913761363dd8569
 - test_case: dcim_console_port_01
   files:
   - path: cassette.yaml
-    sha256: c0f452f871a203ed55562091af812947b97da4ddace3dd34ab22dc5784e82e6b
+    sha256: 60cc246471f872ba469cbd272872b3a5576174370228a97d23fbb099cc68c061
   - path: expected.yaml
     sha256: d1909e90d6b912b1954e9c1408e0b4e24908fc0995983bc78b5362070324431f
 - test_case: dcim_console_ports_01
   files:
   - path: cassette.yaml
-    sha256: 4713945b4f987f69fcac924a43325d14a9084602f82be1ba238ee268b20d57c5
+    sha256: c4111d024e674f306c31b5a07b33411c2557a7a7e3657e2d35037f40632f821f
   - path: expected.yaml
     sha256: 2b93cd11f3b7699ed9ec220f64a8fee2b9e5e0d773e01351f9e7ac39792204f9
 - test_case: dcim_device_01
   files:
   - path: cassette.yaml
-    sha256: a232751b0c496d106a91c9d41929ae50b38c536a3ca4f672e1c2b2d1f23392c4
+    sha256: c039720b9aecd9943bd28ce21ef0f14305eadf6d6825b0d8bcf26eb3e83238af
   - path: expected.yaml
     sha256: 0a750100951c9637fc1e4968e5317e1670fd7ce8eee4b9f341d48764e5039519
 - test_case: dcim_devices_01
   files:
   - path: cassette.yaml
-    sha256: 1df03955bdf6fee595b5211be51bf4aaeb8f5fce7860a90b3665ddfc402486d2
+    sha256: 8b5aebe114836ce94cad568ad465f05ff0ea951a0260142c3a4a9dab81cc30ff
   - path: expected.yaml
     sha256: 9ebcab90a6709ad1688eda13a7a71eda9e53d92596cf1096f42cce36ca7e239c
 - test_case: dcim_interface_trace_01
   files:
   - path: cassette.yaml
-    sha256: 7021e3f649551782c38d52c68a2afbd15cf398c21a34e5e1ec3f9083a5f50959
+    sha256: cc53b0c930c613adbb904b5d1e70709f9ecc97b8417f7ce5fe0fd3eab526423d
   - path: expected.yaml
     sha256: ac36577a7bac4646d91d6ee4c7d129265d04ddc6f35fa9712c5c42362936dab7
 - test_case: dcim_interface_trace_02
   files:
   - path: cassette.yaml
-    sha256: 9402232e2297f95fb57f05408d44d385beb6ab9a3589468bb27c9918054d4cd0
+    sha256: bf18a1bbe0f393d71e10324790eb9661b8ec063c4e694cdde438af509055e4a9
   - path: expected.yaml
     sha256: 4890feabd8a02df6b8fcadfda68a5cd5c34843c57ee2365abe0b8890b88cca0d
 - test_case: dcim_interface_trace_03
   files:
   - path: cassette.yaml
-    sha256: b79e8c3f8013023ccbe5387253e9bee7683f2dcd78f944cf6ac9b06ea0f1319d
+    sha256: c28f9be996e207661e052078f82985d51b56b5f0307e35541f9ffbd3c0fc6deb
   - path: expected.yaml
     sha256: cb15c821321b0959d45f0e30d2ec16e776d02ea0e45f30cea99827aa5cebefba
 - test_case: dcim_site_01
   files:
   - path: cassette.yaml
-    sha256: 5525c1fcb849bc5fd949ab72022d07efa662872ac864931cacbe9a8d7e16322a
+    sha256: 56f849722861fb5a0f68c6b58d156e5e103f8beb084a369baf0873ad4346abe7
   - path: expected.yaml
     sha256: e957cb14ca8051ecd5562183fad1c114fe1dbbf2d07a2c62a7975552096fa7af
 - test_case: dcim_sites_01
   files:
   - path: cassette.yaml
-    sha256: 6c063de6f3191a41877e0f6e80e46ab49e52049bc0d88d04a800d898569e6045
+    sha256: 6459582bfbf6320011a0ee14cecf76e9c270f944550efeb61caa0ece598907b1
   - path: expected.yaml
     sha256: ede96f17e9a8ae662bd6ce97020d81e73b1a603c707d96b48405d250fbe966cb
 - test_case: ipam_all_ip_addresses_01
   files:
   - path: cassette.yaml
-    sha256: 18e829caf619ab3d11859b223aa94c45ebb3c2a7e53dc5280c8984fd523cdd3a
+    sha256: 5336d5c574e1e21ba8e6c8d005ac1a50ebb9ae56f81d0e782efddab190d45389
   - path: expected.yaml
     sha256: b72d91d55ac447e55775899563959459dc94ea2bb1b16b2748a153a46b699027
 - test_case: ipam_ip_address_01
   files:
   - path: cassette.yaml
-    sha256: 2d8059b08aebf07be90b62e19234d55267c99c10cae1881b4edce9e9a5f8380f
+    sha256: 8789e049c70c16d72d0ae15de0f2f3b75379b68a0244d8e3c6028b362d5f84d7
   - path: expected.yaml
     sha256: 5efc947ed2b40a00b5cc02921addf22aa44528acd3fef2b243877cfe1fae406b
 - test_case: ipam_ip_addresses_01
   files:
   - path: cassette.yaml
-    sha256: cec0a2b1ee897f5b7ffb35892c2dec947b300b2e0fbb8cc345126530082e7bdf
+    sha256: 98614049bbf24b564d326b56c1c9e236430083143f55f750d1931ecaf1da9892
   - path: expected.yaml
     sha256: 1ec587c163d383846eac0ba955959e5971ac3523e48e008c50eebc5f725ad035
 - test_case: ipam_vlans_01
   files:
   - path: cassette.yaml
-    sha256: af34f1f6d64d1eac75e9aa6ebf0777214af261846a691ac5b147989077cb790d
+    sha256: 66a794a37df3589c8fa252b0d0c29640c7903808eab8e95f79ab242a3764e8ec
   - path: expected.yaml
     sha256: 880e42c46cd1dff42ec6f389ad6c0b128b380d18371d11bf7e5e1871e1a44237
-sha256: da854aceba63221173b64b47c0296a558d2cbb139f8070e68c1a0056f51ffb98
+sha256: 18959dfd38689bdbea80707969e7c387032a3f7214013a35a20be984008ee9d6

--- a/tests/integration/fixtures/v42/tenancy_tenant_group_01/cassette.yaml
+++ b/tests/integration/fixtures/v42/tenancy_tenant_group_01/cassette.yaml
@@ -1,0 +1,78 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+    method: GET
+    uri: http://localhost:8042/api/tenancy/tenant-groups/?limit=5&offset=0
+  response:
+    body:
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":1,"url":"http://localhost:8042/api/tenancy/tenant-groups/1/","display_url":"http://localhost:8042/tenancy/tenant-groups/1/","display":"Customers","name":"Customers","slug":"customers","parent":null,"description":"","tags":[],"custom_fields":{},"created":"2020-12-19T00:00:00Z","last_updated":"2020-12-19T02:43:53.309000Z","tenant_count":11,"_depth":0}]}'
+    headers:
+      Allow:
+      - GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS
+      Content-Language:
+      - en
+      Content-Length:
+      - '409'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - Unit/1.34.1
+      Vary:
+      - HX-Request, Accept-Language, Cookie, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+    method: GET
+    uri: http://localhost:8042/api/tenancy/tenant-groups/1/
+  response:
+    body:
+      string: '{"id":1,"url":"http://localhost:8042/api/tenancy/tenant-groups/1/","display_url":"http://localhost:8042/tenancy/tenant-groups/1/","display":"Customers","name":"Customers","slug":"customers","parent":null,"description":"","tags":[],"custom_fields":{},"created":"2020-12-19T00:00:00Z","last_updated":"2020-12-19T02:43:53.309000Z","tenant_count":11,"_depth":0}'
+    headers:
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      Content-Language:
+      - en
+      Content-Length:
+      - '357'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - Unit/1.34.1
+      Vary:
+      - HX-Request, Accept-Language, Cookie, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/integration/fixtures/v42/tenancy_tenant_group_01/expected.yaml
+++ b/tests/integration/fixtures/v42/tenancy_tenant_group_01/expected.yaml
@@ -1,0 +1,29 @@
+# AUTO-GENERATED - DO NOT EDIT
+# This file is generated from definitions.yaml
+# To regenerate: python -m tests.integration.generate_fixtures
+
+definition:
+  id: tenancy_tenant_group_01
+  method: tenancy_tenant_group
+  args:
+    tenant_group_id:
+      call: tenancy_tenant_groups
+      args:
+        limit: 5
+      extract: results[0].id
+call:
+  client_call: tenancy_tenant_group
+  client_call_args: []
+  client_call_kwargs:
+    tenant_group_id: 1
+output: !!python/object:annetbox.v42.models.TenantGroup
+  id: 1
+  name: Customers
+  display: Customers
+  url: http://localhost:8042/api/tenancy/tenant-groups/1/
+  slug: customers
+  description: ''
+  custom_fields: {}
+  created: 2020-12-19 00:00:00+00:00
+  last_updated: 2020-12-19 02:43:53.309000+00:00
+  parent: null

--- a/tests/integration/fixtures/v42/tenancy_tenant_groups_01/cassette.yaml
+++ b/tests/integration/fixtures/v42/tenancy_tenant_groups_01/cassette.yaml
@@ -1,0 +1,40 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+    method: GET
+    uri: http://localhost:8042/api/tenancy/tenant-groups/?limit=5&offset=0
+  response:
+    body:
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":1,"url":"http://localhost:8042/api/tenancy/tenant-groups/1/","display_url":"http://localhost:8042/tenancy/tenant-groups/1/","display":"Customers","name":"Customers","slug":"customers","parent":null,"description":"","tags":[],"custom_fields":{},"created":"2020-12-19T00:00:00Z","last_updated":"2020-12-19T02:43:53.309000Z","tenant_count":11,"_depth":0}]}'
+    headers:
+      Allow:
+      - GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS
+      Content-Language:
+      - en
+      Content-Length:
+      - '409'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Server:
+      - Unit/1.34.1
+      Vary:
+      - HX-Request, Accept-Language, Cookie, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/integration/fixtures/v42/tenancy_tenant_groups_01/expected.yaml
+++ b/tests/integration/fixtures/v42/tenancy_tenant_groups_01/expected.yaml
@@ -1,0 +1,30 @@
+# AUTO-GENERATED - DO NOT EDIT
+# This file is generated from definitions.yaml
+# To regenerate: python -m tests.integration.generate_fixtures
+
+definition:
+  id: tenancy_tenant_groups_01
+  method: tenancy_tenant_groups
+  args:
+    limit: 5
+call:
+  client_call: tenancy_tenant_groups
+  client_call_args: []
+  client_call_kwargs:
+    limit: 5
+output: !!python/object:annetbox.base.models.PagingResponse
+  next: null
+  previous: null
+  count: 1
+  results:
+  - !!python/object:annetbox.v42.models.TenantGroup
+    id: 1
+    name: Customers
+    display: Customers
+    url: http://localhost:8042/api/tenancy/tenant-groups/1/
+    slug: customers
+    description: ''
+    custom_fields: {}
+    created: 2020-12-19 00:00:00+00:00
+    last_updated: 2020-12-19 02:43:53.309000+00:00
+    parent: null

--- a/tests/integration/generate_fixtures.py
+++ b/tests/integration/generate_fixtures.py
@@ -117,7 +117,7 @@ def generate_test_case(
         cassette_library_dir=str(test_dir),
         record_mode="all",  # Always re-record
         match_on=["method", "scheme", "host", "port", "path", "query"],
-        filter_headers=[("authorization", "DUMMY")],
+        filter_headers=[("authorization", "DUMMY"), "User-Agent"],
         decode_compressed_response=True,
         serializer="yaml",
         before_record_response=filter_response_headers,


### PR DESCRIPTION
 Adds models and client methods (list/get + collect helpers) for:
    - dcim/regions/ → Region
    - dcim/site-groups/ → SiteGroup
    - dcim/locations/ → Location
    - tenancy/tenant-groups/ → TenantGroup
    