### PR TITLE
feat: add fields for regions, site groups, locations and tenancy to existing models

### DIFF
--- a/src/annetbox/v37/models.py
+++ b/src/annetbox/v37/models.py
@@ -137,13 +137,8 @@ class ConsolePort(Entity):
 
 
 @dataclass
-class Site(Entity):
-    slug: str
-    status: Label
-    custom_fields: dict[str, Any]
-    created: datetime
-    last_updated: datetime
-
+class RegionBrief(EntityWithSlug):
+    pass
 
 @dataclass
 class Region(EntityWithSlug):
@@ -155,12 +150,22 @@ class Region(EntityWithSlug):
 
 
 @dataclass
+class SiteGroupBrief(EntityWithSlug):
+    pass
+
+
+@dataclass
 class SiteGroup(EntityWithSlug):
     description: str
     custom_fields: dict[str, Any]
     created: datetime
     last_updated: datetime
     parent: EntityWithSlug | None = None
+
+
+@dataclass
+class LocationBrief(EntityWithSlug):
+    description: str
 
 
 @dataclass
@@ -177,12 +182,22 @@ class Location(EntityWithSlug):
 
 
 @dataclass
+class TenantGroupBrief(EntityWithSlug):
+    pass
+
+
+@dataclass
 class TenantGroup(EntityWithSlug):
     description: str
     custom_fields: dict[str, Any]
     created: datetime
     last_updated: datetime
     parent: EntityWithSlug | None = None
+
+
+@dataclass
+class TenantBrief(EntityWithSlug):
+    pass
 
 
 @dataclass
@@ -193,7 +208,19 @@ class Tenant(EntityWithSlug):
     custom_fields: dict[str, Any]
     created: datetime
     last_updated: datetime
-    group: EntityWithSlug | None = None
+    group: TenantGroupBrief | None = None
+
+
+@dataclass
+class Site(Entity):
+    slug: str
+    status: Label
+    custom_fields: dict[str, Any]
+    created: datetime
+    last_updated: datetime
+    region: RegionBrief | None = None
+    group: SiteGroupBrief | None = None
+    tenant: TenantBrief | None = None
 
 
 @dataclass
@@ -207,6 +234,7 @@ class Device(Entity):
     serial: str
     asset_tag: str | None
     site: EntityWithSlug
+    location: LocationBrief | None
     rack: Entity | None
     position: float | None
     face: Label | None

--- a/src/annetbox/v41/models.py
+++ b/src/annetbox/v41/models.py
@@ -144,13 +144,8 @@ class ConsolePort(Entity):
 
 
 @dataclass
-class Site(Entity):
-    slug: str
-    status: Label
-    custom_fields: dict[str, Any]
-    created: datetime
-    last_updated: datetime
-
+class RegionBrief(EntityWithSlug):
+    description: str
 
 @dataclass
 class Region(EntityWithSlug):
@@ -162,12 +157,22 @@ class Region(EntityWithSlug):
 
 
 @dataclass
+class SiteGroupBrief(EntityWithSlug):
+    description: str
+
+
+@dataclass
 class SiteGroup(EntityWithSlug):
     description: str
     custom_fields: dict[str, Any]
     created: datetime
     last_updated: datetime
     parent: EntityWithSlug | None = None
+
+
+@dataclass
+class LocationBrief(EntityWithSlug):
+    description: str
 
 
 @dataclass
@@ -184,12 +189,22 @@ class Location(EntityWithSlug):
 
 
 @dataclass
+class TenantGroupBrief(EntityWithSlug):
+    description: str
+
+
+@dataclass
 class TenantGroup(EntityWithSlug):
     description: str
     custom_fields: dict[str, Any]
     created: datetime
     last_updated: datetime
     parent: EntityWithSlug | None = None
+
+
+@dataclass
+class TenantBrief(EntityWithSlug):
+    description: str
 
 
 @dataclass
@@ -200,7 +215,19 @@ class Tenant(EntityWithSlug):
     custom_fields: dict[str, Any]
     created: datetime
     last_updated: datetime
-    group: EntityWithSlug | None = None
+    group: TenantGroupBrief | None = None
+
+
+@dataclass
+class Site(Entity):
+    slug: str
+    status: Label
+    custom_fields: dict[str, Any]
+    created: datetime
+    last_updated: datetime
+    region: RegionBrief | None = None
+    group: SiteGroupBrief | None = None
+    tenant: TenantBrief | None = None
 
 
 @dataclass
@@ -214,6 +241,7 @@ class Device(Entity):
     serial: str
     asset_tag: str | None
     site: EntityWithSlug
+    location: LocationBrief | None
     rack: Entity | None
     position: float | None
     face: Label | None

--- a/src/annetbox/v42/models.py
+++ b/src/annetbox/v42/models.py
@@ -143,13 +143,8 @@ class ConsolePort(Entity):
 
 
 @dataclass
-class Site(Entity):
-    slug: str
-    status: Label
-    custom_fields: dict[str, Any]
-    created: datetime
-    last_updated: datetime
-
+class RegionBrief(EntityWithSlug):
+    description: str
 
 @dataclass
 class Region(EntityWithSlug):
@@ -161,12 +156,22 @@ class Region(EntityWithSlug):
 
 
 @dataclass
+class SiteGroupBrief(EntityWithSlug):
+    description: str
+
+
+@dataclass
 class SiteGroup(EntityWithSlug):
     description: str
     custom_fields: dict[str, Any]
     created: datetime
     last_updated: datetime
     parent: EntityWithSlug | None = None
+
+
+@dataclass
+class LocationBrief(EntityWithSlug):
+    description: str
 
 
 @dataclass
@@ -183,12 +188,22 @@ class Location(EntityWithSlug):
 
 
 @dataclass
+class TenantGroupBrief(EntityWithSlug):
+    description: str
+
+
+@dataclass
 class TenantGroup(EntityWithSlug):
     description: str
     custom_fields: dict[str, Any]
     created: datetime
     last_updated: datetime
     parent: EntityWithSlug | None = None
+
+
+@dataclass
+class TenantBrief(EntityWithSlug):
+    description: str
 
 
 @dataclass
@@ -199,8 +214,19 @@ class Tenant(EntityWithSlug):
     custom_fields: dict[str, Any]
     created: datetime
     last_updated: datetime
-    group: EntityWithSlug | None = None
+    group: TenantGroupBrief | None = None
 
+
+@dataclass
+class Site(Entity):
+    slug: str
+    status: Label
+    custom_fields: dict[str, Any]
+    created: datetime
+    last_updated: datetime
+    region: RegionBrief | None = None
+    group: SiteGroupBrief | None = None
+    tenant: TenantBrief | None = None
 
 @dataclass
 class Device(Entity):
@@ -213,6 +239,7 @@ class Device(Entity):
     serial: str
     asset_tag: str | None
     site: EntityWithSlug
+    location: LocationBrief | None
     rack: Entity | None
     position: float | None
     face: Label | None

--- a/tests/integration/fixtures/v37/dcim_all_devices_01/expected.yaml
+++ b/tests/integration/fixtures/v37/dcim_all_devices_01/expected.yaml
@@ -53,6 +53,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: MDF
       url: http://localhost:8037/api/dcim/sites/21/
       slug: ncsu-065
+    location: null
     rack: !!python/object:annetbox.v37.models.Entity
       id: 41
       name: Plant 1
@@ -118,6 +119,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: MDF
       url: http://localhost:8037/api/dcim/sites/21/
       slug: ncsu-065
+    location: null
     rack: !!python/object:annetbox.v37.models.Entity
       id: 41
       name: Plant 1
@@ -183,6 +185,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: MDF
       url: http://localhost:8037/api/dcim/sites/21/
       slug: ncsu-065
+    location: null
     rack: !!python/object:annetbox.v37.models.Entity
       id: 41
       name: Plant 1
@@ -248,6 +251,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: Butler Communications
       url: http://localhost:8037/api/dcim/sites/24/
       slug: ncsu-128
+    location: null
     rack: !!python/object:annetbox.v37.models.Entity
       id: 39
       name: IDF128
@@ -313,6 +317,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: D. S. Weaver Labs
       url: http://localhost:8037/api/dcim/sites/22/
       slug: ncsu-117
+    location: null
     rack: !!python/object:annetbox.v37.models.Entity
       id: 40
       name: IDF117
@@ -378,6 +383,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: Grinnells Lab
       url: http://localhost:8037/api/dcim/sites/23/
       slug: ncsu-118
+    location: null
     rack: !!python/object:annetbox.v37.models.Entity
       id: 38
       name: IDF118
@@ -443,6 +449,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Akron
       url: http://localhost:8037/api/dcim/sites/2/
       slug: dm-akron
+    location: null
     rack: !!python/object:annetbox.v37.models.Entity
       id: 1
       name: Comms closet
@@ -513,6 +520,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Akron
       url: http://localhost:8037/api/dcim/sites/2/
       slug: dm-akron
+    location: null
     rack: !!python/object:annetbox.v37.models.Entity
       id: 1
       name: Comms closet
@@ -578,6 +586,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Akron
       url: http://localhost:8037/api/dcim/sites/2/
       slug: dm-akron
+    location: null
     rack: !!python/object:annetbox.v37.models.Entity
       id: 1
       name: Comms closet
@@ -643,6 +652,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Albany
       url: http://localhost:8037/api/dcim/sites/3/
       slug: dm-albany
+    location: null
     rack: !!python/object:annetbox.v37.models.Entity
       id: 2
       name: Comms closet
@@ -713,6 +723,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Albany
       url: http://localhost:8037/api/dcim/sites/3/
       slug: dm-albany
+    location: null
     rack: !!python/object:annetbox.v37.models.Entity
       id: 2
       name: Comms closet
@@ -778,6 +789,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Albany
       url: http://localhost:8037/api/dcim/sites/3/
       slug: dm-albany
+    location: null
     rack: !!python/object:annetbox.v37.models.Entity
       id: 2
       name: Comms closet
@@ -843,6 +855,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Binghamton
       url: http://localhost:8037/api/dcim/sites/4/
       slug: dm-binghamton
+    location: null
     rack: !!python/object:annetbox.v37.models.Entity
       id: 3
       name: Comms closet
@@ -913,6 +926,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Binghamton
       url: http://localhost:8037/api/dcim/sites/4/
       slug: dm-binghamton
+    location: null
     rack: !!python/object:annetbox.v37.models.Entity
       id: 3
       name: Comms closet
@@ -978,6 +992,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Binghamton
       url: http://localhost:8037/api/dcim/sites/4/
       slug: dm-binghamton
+    location: null
     rack: !!python/object:annetbox.v37.models.Entity
       id: 3
       name: Comms closet
@@ -1043,6 +1058,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Buffalo
       url: http://localhost:8037/api/dcim/sites/5/
       slug: dm-buffalo
+    location: null
     rack: !!python/object:annetbox.v37.models.Entity
       id: 4
       name: Comms closet
@@ -1113,6 +1129,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Buffalo
       url: http://localhost:8037/api/dcim/sites/5/
       slug: dm-buffalo
+    location: null
     rack: !!python/object:annetbox.v37.models.Entity
       id: 4
       name: Comms closet
@@ -1178,6 +1195,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Buffalo
       url: http://localhost:8037/api/dcim/sites/5/
       slug: dm-buffalo
+    location: null
     rack: !!python/object:annetbox.v37.models.Entity
       id: 4
       name: Comms closet
@@ -1243,6 +1261,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Camden
       url: http://localhost:8037/api/dcim/sites/6/
       slug: dm-camden
+    location: null
     rack: !!python/object:annetbox.v37.models.Entity
       id: 5
       name: Comms closet
@@ -1313,6 +1332,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Camden
       url: http://localhost:8037/api/dcim/sites/6/
       slug: dm-camden
+    location: null
     rack: !!python/object:annetbox.v37.models.Entity
       id: 5
       name: Comms closet
@@ -1378,6 +1398,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Camden
       url: http://localhost:8037/api/dcim/sites/6/
       slug: dm-camden
+    location: null
     rack: !!python/object:annetbox.v37.models.Entity
       id: 5
       name: Comms closet
@@ -1443,6 +1464,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Nashua
       url: http://localhost:8037/api/dcim/sites/7/
       slug: dm-nashua
+    location: null
     rack: !!python/object:annetbox.v37.models.Entity
       id: 6
       name: Comms closet
@@ -1513,6 +1535,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Nashua
       url: http://localhost:8037/api/dcim/sites/7/
       slug: dm-nashua
+    location: null
     rack: !!python/object:annetbox.v37.models.Entity
       id: 6
       name: Comms closet
@@ -1578,6 +1601,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Nashua
       url: http://localhost:8037/api/dcim/sites/7/
       slug: dm-nashua
+    location: null
     rack: !!python/object:annetbox.v37.models.Entity
       id: 6
       name: Comms closet
@@ -1643,6 +1667,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Pittsfield
       url: http://localhost:8037/api/dcim/sites/8/
       slug: dm-pittsfield
+    location: null
     rack: !!python/object:annetbox.v37.models.Entity
       id: 7
       name: Comms closet
@@ -1713,6 +1738,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Pittsfield
       url: http://localhost:8037/api/dcim/sites/8/
       slug: dm-pittsfield
+    location: null
     rack: !!python/object:annetbox.v37.models.Entity
       id: 7
       name: Comms closet
@@ -1778,6 +1804,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Pittsfield
       url: http://localhost:8037/api/dcim/sites/8/
       slug: dm-pittsfield
+    location: null
     rack: !!python/object:annetbox.v37.models.Entity
       id: 7
       name: Comms closet
@@ -1843,6 +1870,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Rochester
       url: http://localhost:8037/api/dcim/sites/9/
       slug: dm-rochester
+    location: null
     rack: !!python/object:annetbox.v37.models.Entity
       id: 8
       name: Comms closet
@@ -1913,6 +1941,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Rochester
       url: http://localhost:8037/api/dcim/sites/9/
       slug: dm-rochester
+    location: null
     rack: !!python/object:annetbox.v37.models.Entity
       id: 8
       name: Comms closet
@@ -1978,6 +2007,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Rochester
       url: http://localhost:8037/api/dcim/sites/9/
       slug: dm-rochester
+    location: null
     rack: !!python/object:annetbox.v37.models.Entity
       id: 8
       name: Comms closet

--- a/tests/integration/fixtures/v37/dcim_device_01/expected.yaml
+++ b/tests/integration/fixtures/v37/dcim_device_01/expected.yaml
@@ -52,6 +52,7 @@ output: !!python/object:annetbox.v37.models.Device
     display: MDF
     url: http://localhost:8037/api/dcim/sites/21/
     slug: ncsu-065
+  location: null
   rack: !!python/object:annetbox.v37.models.Entity
     id: 41
     name: Plant 1

--- a/tests/integration/fixtures/v37/dcim_devices_01/expected.yaml
+++ b/tests/integration/fixtures/v37/dcim_devices_01/expected.yaml
@@ -53,6 +53,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: MDF
       url: http://localhost:8037/api/dcim/sites/21/
       slug: ncsu-065
+    location: null
     rack: !!python/object:annetbox.v37.models.Entity
       id: 41
       name: Plant 1
@@ -118,6 +119,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: MDF
       url: http://localhost:8037/api/dcim/sites/21/
       slug: ncsu-065
+    location: null
     rack: !!python/object:annetbox.v37.models.Entity
       id: 41
       name: Plant 1
@@ -183,6 +185,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: MDF
       url: http://localhost:8037/api/dcim/sites/21/
       slug: ncsu-065
+    location: null
     rack: !!python/object:annetbox.v37.models.Entity
       id: 41
       name: Plant 1
@@ -248,6 +251,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: Butler Communications
       url: http://localhost:8037/api/dcim/sites/24/
       slug: ncsu-128
+    location: null
     rack: !!python/object:annetbox.v37.models.Entity
       id: 39
       name: IDF128
@@ -313,6 +317,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: D. S. Weaver Labs
       url: http://localhost:8037/api/dcim/sites/22/
       slug: ncsu-117
+    location: null
     rack: !!python/object:annetbox.v37.models.Entity
       id: 40
       name: IDF117
@@ -378,6 +383,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: Grinnells Lab
       url: http://localhost:8037/api/dcim/sites/23/
       slug: ncsu-118
+    location: null
     rack: !!python/object:annetbox.v37.models.Entity
       id: 38
       name: IDF118
@@ -443,6 +449,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Akron
       url: http://localhost:8037/api/dcim/sites/2/
       slug: dm-akron
+    location: null
     rack: !!python/object:annetbox.v37.models.Entity
       id: 1
       name: Comms closet
@@ -513,6 +520,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Akron
       url: http://localhost:8037/api/dcim/sites/2/
       slug: dm-akron
+    location: null
     rack: !!python/object:annetbox.v37.models.Entity
       id: 1
       name: Comms closet
@@ -578,6 +586,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Akron
       url: http://localhost:8037/api/dcim/sites/2/
       slug: dm-akron
+    location: null
     rack: !!python/object:annetbox.v37.models.Entity
       id: 1
       name: Comms closet
@@ -643,6 +652,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Albany
       url: http://localhost:8037/api/dcim/sites/3/
       slug: dm-albany
+    location: null
     rack: !!python/object:annetbox.v37.models.Entity
       id: 2
       name: Comms closet

--- a/tests/integration/fixtures/v37/dcim_site_01/expected.yaml
+++ b/tests/integration/fixtures/v37/dcim_site_01/expected.yaml
@@ -28,3 +28,16 @@ output: !!python/object:annetbox.v37.models.Site
   custom_fields: {}
   created: 2021-04-02 00:00:00+00:00
   last_updated: 2021-12-30 15:45:37.371000+00:00
+  region: !!python/object:annetbox.v37.models.RegionBrief
+    id: 40
+    name: North Carolina
+    display: North Carolina
+    url: http://localhost:8037/api/dcim/regions/40/
+    slug: us-nc
+  group: null
+  tenant: !!python/object:annetbox.v37.models.TenantBrief
+    id: 13
+    name: NC State University
+    display: NC State University
+    url: http://localhost:8037/api/tenancy/tenants/13/
+    slug: nc-state

--- a/tests/integration/fixtures/v37/dcim_sites_01/expected.yaml
+++ b/tests/integration/fixtures/v37/dcim_sites_01/expected.yaml
@@ -29,6 +29,19 @@ output: !!python/object:annetbox.base.models.PagingResponse
     custom_fields: {}
     created: 2021-04-02 00:00:00+00:00
     last_updated: 2021-12-30 15:45:37.371000+00:00
+    region: !!python/object:annetbox.v37.models.RegionBrief
+      id: 40
+      name: North Carolina
+      display: North Carolina
+      url: http://localhost:8037/api/dcim/regions/40/
+      slug: us-nc
+    group: null
+    tenant: !!python/object:annetbox.v37.models.TenantBrief
+      id: 13
+      name: NC State University
+      display: NC State University
+      url: http://localhost:8037/api/tenancy/tenants/13/
+      slug: nc-state
   - !!python/object:annetbox.v37.models.Site
     id: 22
     name: D. S. Weaver Labs
@@ -41,6 +54,19 @@ output: !!python/object:annetbox.base.models.PagingResponse
     custom_fields: {}
     created: 2021-04-02 00:00:00+00:00
     last_updated: 2021-12-30 15:45:37.549000+00:00
+    region: !!python/object:annetbox.v37.models.RegionBrief
+      id: 40
+      name: North Carolina
+      display: North Carolina
+      url: http://localhost:8037/api/dcim/regions/40/
+      slug: us-nc
+    group: null
+    tenant: !!python/object:annetbox.v37.models.TenantBrief
+      id: 13
+      name: NC State University
+      display: NC State University
+      url: http://localhost:8037/api/tenancy/tenants/13/
+      slug: nc-state
   - !!python/object:annetbox.v37.models.Site
     id: 2
     name: DM-Akron
@@ -53,6 +79,24 @@ output: !!python/object:annetbox.base.models.PagingResponse
     custom_fields: {}
     created: 2020-12-19 00:00:00+00:00
     last_updated: 2021-12-30 15:45:37.384000+00:00
+    region: !!python/object:annetbox.v37.models.RegionBrief
+      id: 51
+      name: Ohio
+      display: Ohio
+      url: http://localhost:8037/api/dcim/regions/51/
+      slug: us-oh
+    group: !!python/object:annetbox.v37.models.SiteGroupBrief
+      id: 2
+      name: Branch Offices
+      display: Branch Offices
+      url: http://localhost:8037/api/dcim/site-groups/2/
+      slug: branch-offices
+    tenant: !!python/object:annetbox.v37.models.TenantBrief
+      id: 5
+      name: Dunder-Mifflin, Inc.
+      display: Dunder-Mifflin, Inc.
+      url: http://localhost:8037/api/tenancy/tenants/5/
+      slug: dunder-mifflin
   - !!python/object:annetbox.v37.models.Site
     id: 3
     name: DM-Albany
@@ -65,6 +109,24 @@ output: !!python/object:annetbox.base.models.PagingResponse
     custom_fields: {}
     created: 2020-12-19 00:00:00+00:00
     last_updated: 2021-12-30 15:45:37.397000+00:00
+    region: !!python/object:annetbox.v37.models.RegionBrief
+      id: 43
+      name: New York
+      display: New York
+      url: http://localhost:8037/api/dcim/regions/43/
+      slug: us-ny
+    group: !!python/object:annetbox.v37.models.SiteGroupBrief
+      id: 2
+      name: Branch Offices
+      display: Branch Offices
+      url: http://localhost:8037/api/dcim/site-groups/2/
+      slug: branch-offices
+    tenant: !!python/object:annetbox.v37.models.TenantBrief
+      id: 5
+      name: Dunder-Mifflin, Inc.
+      display: Dunder-Mifflin, Inc.
+      url: http://localhost:8037/api/tenancy/tenants/5/
+      slug: dunder-mifflin
   - !!python/object:annetbox.v37.models.Site
     id: 4
     name: DM-Binghamton
@@ -77,3 +139,21 @@ output: !!python/object:annetbox.base.models.PagingResponse
     custom_fields: {}
     created: 2020-12-19 00:00:00+00:00
     last_updated: 2021-12-30 15:45:37.409000+00:00
+    region: !!python/object:annetbox.v37.models.RegionBrief
+      id: 43
+      name: New York
+      display: New York
+      url: http://localhost:8037/api/dcim/regions/43/
+      slug: us-ny
+    group: !!python/object:annetbox.v37.models.SiteGroupBrief
+      id: 2
+      name: Branch Offices
+      display: Branch Offices
+      url: http://localhost:8037/api/dcim/site-groups/2/
+      slug: branch-offices
+    tenant: !!python/object:annetbox.v37.models.TenantBrief
+      id: 5
+      name: Dunder-Mifflin, Inc.
+      display: Dunder-Mifflin, Inc.
+      url: http://localhost:8037/api/tenancy/tenants/5/
+      slug: dunder-mifflin

--- a/tests/integration/fixtures/v37/lock.yaml
+++ b/tests/integration/fixtures/v37/lock.yaml
@@ -44,7 +44,7 @@ test_cases:
   - path: cassette.yaml
     sha256: 17833b459bf20ab8425ae6cca07d021ef6b7574b179569aedc22d40e11e05842
   - path: expected.yaml
-    sha256: 70c9da1fca0ff9fa2335d93d4e68e6df84a4b4f2d596b3585572c5099c662fda
+    sha256: 398fc7c3076a1f1ba0338a66b7ffc181a19fc6141d06565d8a342e9cb68b6103
 - test_case: dcim_all_interfaces_01
   files:
   - path: cassette.yaml
@@ -74,13 +74,13 @@ test_cases:
   - path: cassette.yaml
     sha256: 99523d841490b0c61439c858e1cd81d1ac5038f9fd5173393948e792c5a2086a
   - path: expected.yaml
-    sha256: 1b67901fd3985c3ab45a831ded7e67b41126c156bf30fcea43e63ca4c314416d
+    sha256: c8bb8070a69397db5fab708eb927c16a12e998c95517e5928b20d643963abba5
 - test_case: dcim_devices_01
   files:
   - path: cassette.yaml
     sha256: f36551206f9c3b64aa712ee7ecaabd56ed916fcbf51c6a4ace3515ca46db5307
   - path: expected.yaml
-    sha256: 994c3e3955d819d4f110a0f825b9de2951e3595c7a46bec1513b70868de4820e
+    sha256: f7ff909e650094238f18463e24fc3de8feaa22fd65f063d4b8c1eb5d8e6619f4
 - test_case: dcim_interface_trace_01
   files:
   - path: cassette.yaml
@@ -128,7 +128,7 @@ test_cases:
   - path: cassette.yaml
     sha256: abb755902e538708e076472fc802f71005078bb7b6d00363aa62809b9a640804
   - path: expected.yaml
-    sha256: 7ace4d81d97b6001200963b122cb1f6550e589d7a1b2667e2abf8660d2e70698
+    sha256: 69e32f6dd95cef2ddd0b639f61e482e30c315bcf68238e5740861e274f03f484
 - test_case: dcim_site_group_01
   files:
   - path: cassette.yaml
@@ -146,7 +146,7 @@ test_cases:
   - path: cassette.yaml
     sha256: 44fd6cf5bf0b3d82a34773e0c8e0fcd272fb43adbebb616ff0c29a08a4eba9eb
   - path: expected.yaml
-    sha256: b84d1e363c7899b3abe1542c0a06964d93f1b41778cfe9c0f3eecf1119b574d7
+    sha256: 406cd7abb8f601584c16e3e3f81e70c51940a40375b18a108c4ad3bf9531b640
 - test_case: ipam_all_ip_addresses_01
   files:
   - path: cassette.yaml
@@ -170,7 +170,7 @@ test_cases:
   - path: cassette.yaml
     sha256: b86b9574bc71eacfd8545ba2d7782f32fd11a64309ba5ac88a33840c4877e77c
   - path: expected.yaml
-    sha256: fa5a52b3ebf5983a2f64ba4984cbb6df246fdb4b32db240f571159d647801096
+    sha256: 17960a53ecef6c1a87b9803cb46eba5888d4c797fe59fd10054ffc12e4499613
 - test_case: tenancy_tenant_group_01
   files:
   - path: cassette.yaml
@@ -188,5 +188,5 @@ test_cases:
   - path: cassette.yaml
     sha256: f4feb1034b14a6fbdfc30153d7d341af08fbb0915718f4c50a24271e40a35006
   - path: expected.yaml
-    sha256: 3089e7f7c8b473b82fb1a247e74b1a3a8fa5c8e91b868684923e4a3684051ad8
-sha256: 6ba4a14fd9786dd8a055c5e8eabe2517c198bdc62a77d8dadada7818bb543a4d
+    sha256: ffc41877a53ca80d26bca7848243e5268e038874a16831f39bb03c4a7f06ef61
+sha256: fd7184a62ec6436a2ee8316ffbfc1cf92f433952d2f3849a037057d42f92a082

--- a/tests/integration/fixtures/v37/tenancy_tenant_01/expected.yaml
+++ b/tests/integration/fixtures/v37/tenancy_tenant_01/expected.yaml
@@ -29,7 +29,7 @@ output: !!python/object:annetbox.v37.models.Tenant
     cust_id: CYB01
   created: 2020-12-19 00:00:00+00:00
   last_updated: 2020-12-30 18:43:27.449000+00:00
-  group: !!python/object:annetbox.v37.models.EntityWithSlug
+  group: !!python/object:annetbox.v37.models.TenantGroupBrief
     id: 1
     name: Customers
     display: Customers

--- a/tests/integration/fixtures/v37/tenancy_tenants_01/expected.yaml
+++ b/tests/integration/fixtures/v37/tenancy_tenants_01/expected.yaml
@@ -30,7 +30,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       cust_id: CYB01
     created: 2020-12-19 00:00:00+00:00
     last_updated: 2020-12-30 18:43:27.449000+00:00
-    group: !!python/object:annetbox.v37.models.EntityWithSlug
+    group: !!python/object:annetbox.v37.models.TenantGroupBrief
       id: 1
       name: Customers
       display: Customers
@@ -49,7 +49,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       cust_id: DMI01
     created: 2020-12-19 00:00:00+00:00
     last_updated: 2020-12-30 18:43:27.515000+00:00
-    group: !!python/object:annetbox.v37.models.EntityWithSlug
+    group: !!python/object:annetbox.v37.models.TenantGroupBrief
       id: 1
       name: Customers
       display: Customers
@@ -68,7 +68,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       cust_id: INI04
     created: 2020-12-19 00:00:00+00:00
     last_updated: 2020-12-30 18:43:27.571000+00:00
-    group: !!python/object:annetbox.v37.models.EntityWithSlug
+    group: !!python/object:annetbox.v37.models.TenantGroupBrief
       id: 1
       name: Customers
       display: Customers
@@ -87,7 +87,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       cust_id: ''
     created: 2021-03-10 00:00:00+00:00
     last_updated: 2021-03-10 20:44:16.078000+00:00
-    group: !!python/object:annetbox.v37.models.EntityWithSlug
+    group: !!python/object:annetbox.v37.models.TenantGroupBrief
       id: 1
       name: Customers
       display: Customers
@@ -106,7 +106,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       cust_id: ''
     created: 2021-04-02 00:00:00+00:00
     last_updated: 2021-04-02 16:46:50.851000+00:00
-    group: !!python/object:annetbox.v37.models.EntityWithSlug
+    group: !!python/object:annetbox.v37.models.TenantGroupBrief
       id: 1
       name: Customers
       display: Customers

--- a/tests/integration/fixtures/v41/dcim_all_devices_01/expected.yaml
+++ b/tests/integration/fixtures/v41/dcim_all_devices_01/expected.yaml
@@ -53,6 +53,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: MDF
       url: http://localhost:8041/api/dcim/sites/21/
       slug: ncsu-065
+    location: null
     rack: !!python/object:annetbox.v41.models.Entity
       id: 41
       name: Plant 1
@@ -112,6 +113,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: MDF
       url: http://localhost:8041/api/dcim/sites/21/
       slug: ncsu-065
+    location: null
     rack: !!python/object:annetbox.v41.models.Entity
       id: 41
       name: Plant 1
@@ -171,6 +173,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: MDF
       url: http://localhost:8041/api/dcim/sites/21/
       slug: ncsu-065
+    location: null
     rack: !!python/object:annetbox.v41.models.Entity
       id: 41
       name: Plant 1
@@ -230,6 +233,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: Butler Communications
       url: http://localhost:8041/api/dcim/sites/24/
       slug: ncsu-128
+    location: null
     rack: !!python/object:annetbox.v41.models.Entity
       id: 39
       name: IDF128
@@ -289,6 +293,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: D. S. Weaver Labs
       url: http://localhost:8041/api/dcim/sites/22/
       slug: ncsu-117
+    location: null
     rack: !!python/object:annetbox.v41.models.Entity
       id: 40
       name: IDF117
@@ -348,6 +353,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: Grinnells Lab
       url: http://localhost:8041/api/dcim/sites/23/
       slug: ncsu-118
+    location: null
     rack: !!python/object:annetbox.v41.models.Entity
       id: 38
       name: IDF118
@@ -407,6 +413,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Akron
       url: http://localhost:8041/api/dcim/sites/2/
       slug: dm-akron
+    location: null
     rack: !!python/object:annetbox.v41.models.Entity
       id: 1
       name: Comms closet
@@ -471,6 +478,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Akron
       url: http://localhost:8041/api/dcim/sites/2/
       slug: dm-akron
+    location: null
     rack: !!python/object:annetbox.v41.models.Entity
       id: 1
       name: Comms closet
@@ -530,6 +538,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Akron
       url: http://localhost:8041/api/dcim/sites/2/
       slug: dm-akron
+    location: null
     rack: !!python/object:annetbox.v41.models.Entity
       id: 1
       name: Comms closet
@@ -589,6 +598,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Albany
       url: http://localhost:8041/api/dcim/sites/3/
       slug: dm-albany
+    location: null
     rack: !!python/object:annetbox.v41.models.Entity
       id: 2
       name: Comms closet
@@ -653,6 +663,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Albany
       url: http://localhost:8041/api/dcim/sites/3/
       slug: dm-albany
+    location: null
     rack: !!python/object:annetbox.v41.models.Entity
       id: 2
       name: Comms closet
@@ -712,6 +723,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Albany
       url: http://localhost:8041/api/dcim/sites/3/
       slug: dm-albany
+    location: null
     rack: !!python/object:annetbox.v41.models.Entity
       id: 2
       name: Comms closet
@@ -771,6 +783,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Binghamton
       url: http://localhost:8041/api/dcim/sites/4/
       slug: dm-binghamton
+    location: null
     rack: !!python/object:annetbox.v41.models.Entity
       id: 3
       name: Comms closet
@@ -835,6 +848,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Binghamton
       url: http://localhost:8041/api/dcim/sites/4/
       slug: dm-binghamton
+    location: null
     rack: !!python/object:annetbox.v41.models.Entity
       id: 3
       name: Comms closet
@@ -894,6 +908,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Binghamton
       url: http://localhost:8041/api/dcim/sites/4/
       slug: dm-binghamton
+    location: null
     rack: !!python/object:annetbox.v41.models.Entity
       id: 3
       name: Comms closet
@@ -953,6 +968,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Buffalo
       url: http://localhost:8041/api/dcim/sites/5/
       slug: dm-buffalo
+    location: null
     rack: !!python/object:annetbox.v41.models.Entity
       id: 4
       name: Comms closet
@@ -1017,6 +1033,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Buffalo
       url: http://localhost:8041/api/dcim/sites/5/
       slug: dm-buffalo
+    location: null
     rack: !!python/object:annetbox.v41.models.Entity
       id: 4
       name: Comms closet
@@ -1076,6 +1093,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Buffalo
       url: http://localhost:8041/api/dcim/sites/5/
       slug: dm-buffalo
+    location: null
     rack: !!python/object:annetbox.v41.models.Entity
       id: 4
       name: Comms closet
@@ -1135,6 +1153,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Camden
       url: http://localhost:8041/api/dcim/sites/6/
       slug: dm-camden
+    location: null
     rack: !!python/object:annetbox.v41.models.Entity
       id: 5
       name: Comms closet
@@ -1199,6 +1218,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Camden
       url: http://localhost:8041/api/dcim/sites/6/
       slug: dm-camden
+    location: null
     rack: !!python/object:annetbox.v41.models.Entity
       id: 5
       name: Comms closet
@@ -1258,6 +1278,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Camden
       url: http://localhost:8041/api/dcim/sites/6/
       slug: dm-camden
+    location: null
     rack: !!python/object:annetbox.v41.models.Entity
       id: 5
       name: Comms closet
@@ -1317,6 +1338,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Nashua
       url: http://localhost:8041/api/dcim/sites/7/
       slug: dm-nashua
+    location: null
     rack: !!python/object:annetbox.v41.models.Entity
       id: 6
       name: Comms closet
@@ -1381,6 +1403,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Nashua
       url: http://localhost:8041/api/dcim/sites/7/
       slug: dm-nashua
+    location: null
     rack: !!python/object:annetbox.v41.models.Entity
       id: 6
       name: Comms closet
@@ -1440,6 +1463,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Nashua
       url: http://localhost:8041/api/dcim/sites/7/
       slug: dm-nashua
+    location: null
     rack: !!python/object:annetbox.v41.models.Entity
       id: 6
       name: Comms closet
@@ -1499,6 +1523,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Pittsfield
       url: http://localhost:8041/api/dcim/sites/8/
       slug: dm-pittsfield
+    location: null
     rack: !!python/object:annetbox.v41.models.Entity
       id: 7
       name: Comms closet
@@ -1563,6 +1588,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Pittsfield
       url: http://localhost:8041/api/dcim/sites/8/
       slug: dm-pittsfield
+    location: null
     rack: !!python/object:annetbox.v41.models.Entity
       id: 7
       name: Comms closet
@@ -1622,6 +1648,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Pittsfield
       url: http://localhost:8041/api/dcim/sites/8/
       slug: dm-pittsfield
+    location: null
     rack: !!python/object:annetbox.v41.models.Entity
       id: 7
       name: Comms closet
@@ -1681,6 +1708,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Rochester
       url: http://localhost:8041/api/dcim/sites/9/
       slug: dm-rochester
+    location: null
     rack: !!python/object:annetbox.v41.models.Entity
       id: 8
       name: Comms closet
@@ -1745,6 +1773,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Rochester
       url: http://localhost:8041/api/dcim/sites/9/
       slug: dm-rochester
+    location: null
     rack: !!python/object:annetbox.v41.models.Entity
       id: 8
       name: Comms closet
@@ -1804,6 +1833,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Rochester
       url: http://localhost:8041/api/dcim/sites/9/
       slug: dm-rochester
+    location: null
     rack: !!python/object:annetbox.v41.models.Entity
       id: 8
       name: Comms closet

--- a/tests/integration/fixtures/v41/dcim_device_01/expected.yaml
+++ b/tests/integration/fixtures/v41/dcim_device_01/expected.yaml
@@ -52,6 +52,7 @@ output: !!python/object:annetbox.v41.models.Device
     display: MDF
     url: http://localhost:8041/api/dcim/sites/21/
     slug: ncsu-065
+  location: null
   rack: !!python/object:annetbox.v41.models.Entity
     id: 41
     name: Plant 1

--- a/tests/integration/fixtures/v41/dcim_devices_01/expected.yaml
+++ b/tests/integration/fixtures/v41/dcim_devices_01/expected.yaml
@@ -53,6 +53,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: MDF
       url: http://localhost:8041/api/dcim/sites/21/
       slug: ncsu-065
+    location: null
     rack: !!python/object:annetbox.v41.models.Entity
       id: 41
       name: Plant 1
@@ -112,6 +113,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: MDF
       url: http://localhost:8041/api/dcim/sites/21/
       slug: ncsu-065
+    location: null
     rack: !!python/object:annetbox.v41.models.Entity
       id: 41
       name: Plant 1
@@ -171,6 +173,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: MDF
       url: http://localhost:8041/api/dcim/sites/21/
       slug: ncsu-065
+    location: null
     rack: !!python/object:annetbox.v41.models.Entity
       id: 41
       name: Plant 1
@@ -230,6 +233,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: Butler Communications
       url: http://localhost:8041/api/dcim/sites/24/
       slug: ncsu-128
+    location: null
     rack: !!python/object:annetbox.v41.models.Entity
       id: 39
       name: IDF128
@@ -289,6 +293,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: D. S. Weaver Labs
       url: http://localhost:8041/api/dcim/sites/22/
       slug: ncsu-117
+    location: null
     rack: !!python/object:annetbox.v41.models.Entity
       id: 40
       name: IDF117
@@ -348,6 +353,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: Grinnells Lab
       url: http://localhost:8041/api/dcim/sites/23/
       slug: ncsu-118
+    location: null
     rack: !!python/object:annetbox.v41.models.Entity
       id: 38
       name: IDF118
@@ -407,6 +413,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Akron
       url: http://localhost:8041/api/dcim/sites/2/
       slug: dm-akron
+    location: null
     rack: !!python/object:annetbox.v41.models.Entity
       id: 1
       name: Comms closet
@@ -471,6 +478,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Akron
       url: http://localhost:8041/api/dcim/sites/2/
       slug: dm-akron
+    location: null
     rack: !!python/object:annetbox.v41.models.Entity
       id: 1
       name: Comms closet
@@ -530,6 +538,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Akron
       url: http://localhost:8041/api/dcim/sites/2/
       slug: dm-akron
+    location: null
     rack: !!python/object:annetbox.v41.models.Entity
       id: 1
       name: Comms closet
@@ -589,6 +598,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Albany
       url: http://localhost:8041/api/dcim/sites/3/
       slug: dm-albany
+    location: null
     rack: !!python/object:annetbox.v41.models.Entity
       id: 2
       name: Comms closet

--- a/tests/integration/fixtures/v41/dcim_site_01/expected.yaml
+++ b/tests/integration/fixtures/v41/dcim_site_01/expected.yaml
@@ -28,3 +28,18 @@ output: !!python/object:annetbox.v41.models.Site
   custom_fields: {}
   created: 2021-04-02 00:00:00+00:00
   last_updated: 2021-12-30 15:45:37.371000+00:00
+  region: !!python/object:annetbox.v41.models.RegionBrief
+    id: 40
+    name: North Carolina
+    display: North Carolina
+    url: http://localhost:8041/api/dcim/regions/40/
+    slug: us-nc
+    description: ''
+  group: null
+  tenant: !!python/object:annetbox.v41.models.TenantBrief
+    id: 13
+    name: NC State University
+    display: NC State University
+    url: http://localhost:8041/api/tenancy/tenants/13/
+    slug: nc-state
+    description: ''

--- a/tests/integration/fixtures/v41/dcim_sites_01/expected.yaml
+++ b/tests/integration/fixtures/v41/dcim_sites_01/expected.yaml
@@ -29,6 +29,21 @@ output: !!python/object:annetbox.base.models.PagingResponse
     custom_fields: {}
     created: 2021-04-02 00:00:00+00:00
     last_updated: 2021-12-30 15:45:37.371000+00:00
+    region: !!python/object:annetbox.v41.models.RegionBrief
+      id: 40
+      name: North Carolina
+      display: North Carolina
+      url: http://localhost:8041/api/dcim/regions/40/
+      slug: us-nc
+      description: ''
+    group: null
+    tenant: !!python/object:annetbox.v41.models.TenantBrief
+      id: 13
+      name: NC State University
+      display: NC State University
+      url: http://localhost:8041/api/tenancy/tenants/13/
+      slug: nc-state
+      description: ''
   - !!python/object:annetbox.v41.models.Site
     id: 22
     name: D. S. Weaver Labs
@@ -41,6 +56,21 @@ output: !!python/object:annetbox.base.models.PagingResponse
     custom_fields: {}
     created: 2021-04-02 00:00:00+00:00
     last_updated: 2021-12-30 15:45:37.549000+00:00
+    region: !!python/object:annetbox.v41.models.RegionBrief
+      id: 40
+      name: North Carolina
+      display: North Carolina
+      url: http://localhost:8041/api/dcim/regions/40/
+      slug: us-nc
+      description: ''
+    group: null
+    tenant: !!python/object:annetbox.v41.models.TenantBrief
+      id: 13
+      name: NC State University
+      display: NC State University
+      url: http://localhost:8041/api/tenancy/tenants/13/
+      slug: nc-state
+      description: ''
   - !!python/object:annetbox.v41.models.Site
     id: 2
     name: DM-Akron
@@ -53,6 +83,27 @@ output: !!python/object:annetbox.base.models.PagingResponse
     custom_fields: {}
     created: 2020-12-19 00:00:00+00:00
     last_updated: 2021-12-30 15:45:37.384000+00:00
+    region: !!python/object:annetbox.v41.models.RegionBrief
+      id: 51
+      name: Ohio
+      display: Ohio
+      url: http://localhost:8041/api/dcim/regions/51/
+      slug: us-oh
+      description: ''
+    group: !!python/object:annetbox.v41.models.SiteGroupBrief
+      id: 2
+      name: Branch Offices
+      display: Branch Offices
+      url: http://localhost:8041/api/dcim/site-groups/2/
+      slug: branch-offices
+      description: ''
+    tenant: !!python/object:annetbox.v41.models.TenantBrief
+      id: 5
+      name: Dunder-Mifflin, Inc.
+      display: Dunder-Mifflin, Inc.
+      url: http://localhost:8041/api/tenancy/tenants/5/
+      slug: dunder-mifflin
+      description: ''
   - !!python/object:annetbox.v41.models.Site
     id: 3
     name: DM-Albany
@@ -65,6 +116,27 @@ output: !!python/object:annetbox.base.models.PagingResponse
     custom_fields: {}
     created: 2020-12-19 00:00:00+00:00
     last_updated: 2021-12-30 15:45:37.397000+00:00
+    region: !!python/object:annetbox.v41.models.RegionBrief
+      id: 43
+      name: New York
+      display: New York
+      url: http://localhost:8041/api/dcim/regions/43/
+      slug: us-ny
+      description: ''
+    group: !!python/object:annetbox.v41.models.SiteGroupBrief
+      id: 2
+      name: Branch Offices
+      display: Branch Offices
+      url: http://localhost:8041/api/dcim/site-groups/2/
+      slug: branch-offices
+      description: ''
+    tenant: !!python/object:annetbox.v41.models.TenantBrief
+      id: 5
+      name: Dunder-Mifflin, Inc.
+      display: Dunder-Mifflin, Inc.
+      url: http://localhost:8041/api/tenancy/tenants/5/
+      slug: dunder-mifflin
+      description: ''
   - !!python/object:annetbox.v41.models.Site
     id: 4
     name: DM-Binghamton
@@ -77,3 +149,24 @@ output: !!python/object:annetbox.base.models.PagingResponse
     custom_fields: {}
     created: 2020-12-19 00:00:00+00:00
     last_updated: 2021-12-30 15:45:37.409000+00:00
+    region: !!python/object:annetbox.v41.models.RegionBrief
+      id: 43
+      name: New York
+      display: New York
+      url: http://localhost:8041/api/dcim/regions/43/
+      slug: us-ny
+      description: ''
+    group: !!python/object:annetbox.v41.models.SiteGroupBrief
+      id: 2
+      name: Branch Offices
+      display: Branch Offices
+      url: http://localhost:8041/api/dcim/site-groups/2/
+      slug: branch-offices
+      description: ''
+    tenant: !!python/object:annetbox.v41.models.TenantBrief
+      id: 5
+      name: Dunder-Mifflin, Inc.
+      display: Dunder-Mifflin, Inc.
+      url: http://localhost:8041/api/tenancy/tenants/5/
+      slug: dunder-mifflin
+      description: ''

--- a/tests/integration/fixtures/v41/lock.yaml
+++ b/tests/integration/fixtures/v41/lock.yaml
@@ -44,7 +44,7 @@ test_cases:
   - path: cassette.yaml
     sha256: bfc4daec83b2529210f73a3e7632975d664e305e612bea61ec6a9574eb051765
   - path: expected.yaml
-    sha256: 5fe6dc67fdd80959f88c3dc30c5fc2a817403aecf708a4ecfe86861438822ea7
+    sha256: 47769867ef6f9931150ac71ec3fa3d88d2d7434c8547bf2e105ccfcc93b3a442
 - test_case: dcim_all_interfaces_01
   files:
   - path: cassette.yaml
@@ -74,13 +74,13 @@ test_cases:
   - path: cassette.yaml
     sha256: 147719c1874fd4672e2e91a52b6d73c41a4e48d5691ffa5d844a793cc607e947
   - path: expected.yaml
-    sha256: 6fd72e505838001cb3113e8727e03aed804e9883e83fc6c1778481d9a7a4032d
+    sha256: d5cf08e051cc4d8b6a6796779bf891275dd20ac5b5a6490e294440c731b43977
 - test_case: dcim_devices_01
   files:
   - path: cassette.yaml
     sha256: 836310f1f247925279af57b6ce36dd2cc99e8695abb2292289c3ef23b1eff43f
   - path: expected.yaml
-    sha256: c654fb9f2516c7575e768ed31275a2ce9dd9aff7e64f50a47f59d40ac5926b62
+    sha256: 48a3745344a71692c9b5880221cdd1cba29a980a85db06f74c39996fe9b6785e
 - test_case: dcim_interface_trace_01
   files:
   - path: cassette.yaml
@@ -128,7 +128,7 @@ test_cases:
   - path: cassette.yaml
     sha256: 51c43e3c157baaf0639a06246de96ab25913f5c03bb2943239cada93321d0c87
   - path: expected.yaml
-    sha256: 87d71ec80096618164ebe4de1bcbc39d416fd091aae7de1bf6839e9e4fec5ae9
+    sha256: ede92eaf8bd1f357be4585ed51278e74d8e2acd7c83493faa040b4ea16a6e078
 - test_case: dcim_site_group_01
   files:
   - path: cassette.yaml
@@ -146,7 +146,7 @@ test_cases:
   - path: cassette.yaml
     sha256: 4a703352b015b9ebc01e55a0b77a47ac9f247e687f9d9a613c25e6a26b3b0d18
   - path: expected.yaml
-    sha256: f7a77a2eb82d1a489c659ee7338b374add3075edf95d3944145f2e04fcf167f6
+    sha256: 4baac8958551439b64fa1de9d72ac2b35796025f50b16d6870e7eb07b8133c8a
 - test_case: ipam_all_ip_addresses_01
   files:
   - path: cassette.yaml
@@ -170,7 +170,7 @@ test_cases:
   - path: cassette.yaml
     sha256: 6961907794714f7748ec6b38c35e6079d7448ad41706a83c745677719cc7bf6a
   - path: expected.yaml
-    sha256: a04742b52578a646f4a13eaf9fcc7a97d9fb5bd909685ed4445e1ff16eed361c
+    sha256: 4e8a51acc004bda62420ebf1e0afd58347c865b6d611db8157f6f32d78bd7d02
 - test_case: tenancy_tenant_group_01
   files:
   - path: cassette.yaml
@@ -188,5 +188,5 @@ test_cases:
   - path: cassette.yaml
     sha256: d5f3808b3bd12a2239751c9db7e15163ba0c44a524520b6b9651b66f947cc623
   - path: expected.yaml
-    sha256: 1ddfc9839fed1a895896598b0cb8338b3c04b3db172a955dfce90204a4628187
-sha256: 8d14c5496fd80fe88cade66572cd091f5726e244e0cb54dfa639125c0ce8d9d9
+    sha256: d904cf9e74e3f25967466befae59a7fddbfc07623f3e6340fca62c8eb53b5009
+sha256: 02eed562a418b325269595efc0166d2cb21b51927af0723f790ecbaa3331d22a

--- a/tests/integration/fixtures/v41/tenancy_tenant_01/expected.yaml
+++ b/tests/integration/fixtures/v41/tenancy_tenant_01/expected.yaml
@@ -29,9 +29,10 @@ output: !!python/object:annetbox.v41.models.Tenant
     cust_id: CYB01
   created: 2020-12-19 00:00:00+00:00
   last_updated: 2020-12-30 18:43:27.449000+00:00
-  group: !!python/object:annetbox.v41.models.EntityWithSlug
+  group: !!python/object:annetbox.v41.models.TenantGroupBrief
     id: 1
     name: Customers
     display: Customers
     url: http://localhost:8041/api/tenancy/tenant-groups/1/
     slug: customers
+    description: ''

--- a/tests/integration/fixtures/v41/tenancy_tenants_01/expected.yaml
+++ b/tests/integration/fixtures/v41/tenancy_tenants_01/expected.yaml
@@ -30,12 +30,13 @@ output: !!python/object:annetbox.base.models.PagingResponse
       cust_id: CYB01
     created: 2020-12-19 00:00:00+00:00
     last_updated: 2020-12-30 18:43:27.449000+00:00
-    group: !!python/object:annetbox.v41.models.EntityWithSlug
+    group: !!python/object:annetbox.v41.models.TenantGroupBrief
       id: 1
       name: Customers
       display: Customers
       url: http://localhost:8041/api/tenancy/tenant-groups/1/
       slug: customers
+      description: ''
   - !!python/object:annetbox.v41.models.Tenant
     id: 5
     name: Dunder-Mifflin, Inc.
@@ -49,12 +50,13 @@ output: !!python/object:annetbox.base.models.PagingResponse
       cust_id: DMI01
     created: 2020-12-19 00:00:00+00:00
     last_updated: 2020-12-30 18:43:27.515000+00:00
-    group: !!python/object:annetbox.v41.models.EntityWithSlug
+    group: !!python/object:annetbox.v41.models.TenantGroupBrief
       id: 1
       name: Customers
       display: Customers
       url: http://localhost:8041/api/tenancy/tenant-groups/1/
       slug: customers
+      description: ''
   - !!python/object:annetbox.v41.models.Tenant
     id: 1
     name: Initech
@@ -68,12 +70,13 @@ output: !!python/object:annetbox.base.models.PagingResponse
       cust_id: INI04
     created: 2020-12-19 00:00:00+00:00
     last_updated: 2020-12-30 18:43:27.571000+00:00
-    group: !!python/object:annetbox.v41.models.EntityWithSlug
+    group: !!python/object:annetbox.v41.models.TenantGroupBrief
       id: 1
       name: Customers
       display: Customers
       url: http://localhost:8041/api/tenancy/tenant-groups/1/
       slug: customers
+      description: ''
   - !!python/object:annetbox.v41.models.Tenant
     id: 10
     name: Jimbob's Banking & Trust
@@ -87,12 +90,13 @@ output: !!python/object:annetbox.base.models.PagingResponse
       cust_id: ''
     created: 2021-03-10 00:00:00+00:00
     last_updated: 2021-03-10 20:44:16.078000+00:00
-    group: !!python/object:annetbox.v41.models.EntityWithSlug
+    group: !!python/object:annetbox.v41.models.TenantGroupBrief
       id: 1
       name: Customers
       display: Customers
       url: http://localhost:8041/api/tenancy/tenant-groups/1/
       slug: customers
+      description: ''
   - !!python/object:annetbox.v41.models.Tenant
     id: 13
     name: NC State University
@@ -106,9 +110,10 @@ output: !!python/object:annetbox.base.models.PagingResponse
       cust_id: ''
     created: 2021-04-02 00:00:00+00:00
     last_updated: 2021-04-02 16:46:50.851000+00:00
-    group: !!python/object:annetbox.v41.models.EntityWithSlug
+    group: !!python/object:annetbox.v41.models.TenantGroupBrief
       id: 1
       name: Customers
       display: Customers
       url: http://localhost:8041/api/tenancy/tenant-groups/1/
       slug: customers
+      description: ''

--- a/tests/integration/fixtures/v42/dcim_all_devices_01/expected.yaml
+++ b/tests/integration/fixtures/v42/dcim_all_devices_01/expected.yaml
@@ -53,6 +53,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Akron
       url: http://localhost:8042/api/dcim/sites/2/
       slug: dm-akron
+    location: null
     rack: !!python/object:annetbox.v42.models.Entity
       id: 1
       name: Comms closet
@@ -117,6 +118,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Akron
       url: http://localhost:8042/api/dcim/sites/2/
       slug: dm-akron
+    location: null
     rack: !!python/object:annetbox.v42.models.Entity
       id: 1
       name: Comms closet
@@ -176,6 +178,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Akron
       url: http://localhost:8042/api/dcim/sites/2/
       slug: dm-akron
+    location: null
     rack: !!python/object:annetbox.v42.models.Entity
       id: 1
       name: Comms closet
@@ -235,6 +238,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Albany
       url: http://localhost:8042/api/dcim/sites/3/
       slug: dm-albany
+    location: null
     rack: !!python/object:annetbox.v42.models.Entity
       id: 2
       name: Comms closet
@@ -299,6 +303,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Albany
       url: http://localhost:8042/api/dcim/sites/3/
       slug: dm-albany
+    location: null
     rack: !!python/object:annetbox.v42.models.Entity
       id: 2
       name: Comms closet
@@ -358,6 +363,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Albany
       url: http://localhost:8042/api/dcim/sites/3/
       slug: dm-albany
+    location: null
     rack: !!python/object:annetbox.v42.models.Entity
       id: 2
       name: Comms closet
@@ -417,6 +423,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Binghamton
       url: http://localhost:8042/api/dcim/sites/4/
       slug: dm-binghamton
+    location: null
     rack: !!python/object:annetbox.v42.models.Entity
       id: 3
       name: Comms closet
@@ -481,6 +488,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Binghamton
       url: http://localhost:8042/api/dcim/sites/4/
       slug: dm-binghamton
+    location: null
     rack: !!python/object:annetbox.v42.models.Entity
       id: 3
       name: Comms closet
@@ -540,6 +548,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Binghamton
       url: http://localhost:8042/api/dcim/sites/4/
       slug: dm-binghamton
+    location: null
     rack: !!python/object:annetbox.v42.models.Entity
       id: 3
       name: Comms closet
@@ -599,6 +608,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Buffalo
       url: http://localhost:8042/api/dcim/sites/5/
       slug: dm-buffalo
+    location: null
     rack: !!python/object:annetbox.v42.models.Entity
       id: 4
       name: Comms closet
@@ -663,6 +673,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Buffalo
       url: http://localhost:8042/api/dcim/sites/5/
       slug: dm-buffalo
+    location: null
     rack: !!python/object:annetbox.v42.models.Entity
       id: 4
       name: Comms closet
@@ -722,6 +733,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Buffalo
       url: http://localhost:8042/api/dcim/sites/5/
       slug: dm-buffalo
+    location: null
     rack: !!python/object:annetbox.v42.models.Entity
       id: 4
       name: Comms closet
@@ -781,6 +793,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Camden
       url: http://localhost:8042/api/dcim/sites/6/
       slug: dm-camden
+    location: null
     rack: !!python/object:annetbox.v42.models.Entity
       id: 5
       name: Comms closet
@@ -845,6 +858,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Camden
       url: http://localhost:8042/api/dcim/sites/6/
       slug: dm-camden
+    location: null
     rack: !!python/object:annetbox.v42.models.Entity
       id: 5
       name: Comms closet
@@ -904,6 +918,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Camden
       url: http://localhost:8042/api/dcim/sites/6/
       slug: dm-camden
+    location: null
     rack: !!python/object:annetbox.v42.models.Entity
       id: 5
       name: Comms closet
@@ -963,6 +978,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Nashua
       url: http://localhost:8042/api/dcim/sites/7/
       slug: dm-nashua
+    location: null
     rack: !!python/object:annetbox.v42.models.Entity
       id: 6
       name: Comms closet
@@ -1027,6 +1043,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Nashua
       url: http://localhost:8042/api/dcim/sites/7/
       slug: dm-nashua
+    location: null
     rack: !!python/object:annetbox.v42.models.Entity
       id: 6
       name: Comms closet
@@ -1086,6 +1103,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Nashua
       url: http://localhost:8042/api/dcim/sites/7/
       slug: dm-nashua
+    location: null
     rack: !!python/object:annetbox.v42.models.Entity
       id: 6
       name: Comms closet
@@ -1145,6 +1163,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Pittsfield
       url: http://localhost:8042/api/dcim/sites/8/
       slug: dm-pittsfield
+    location: null
     rack: !!python/object:annetbox.v42.models.Entity
       id: 7
       name: Comms closet
@@ -1209,6 +1228,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Pittsfield
       url: http://localhost:8042/api/dcim/sites/8/
       slug: dm-pittsfield
+    location: null
     rack: !!python/object:annetbox.v42.models.Entity
       id: 7
       name: Comms closet
@@ -1268,6 +1288,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Pittsfield
       url: http://localhost:8042/api/dcim/sites/8/
       slug: dm-pittsfield
+    location: null
     rack: !!python/object:annetbox.v42.models.Entity
       id: 7
       name: Comms closet
@@ -1327,6 +1348,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Rochester
       url: http://localhost:8042/api/dcim/sites/9/
       slug: dm-rochester
+    location: null
     rack: !!python/object:annetbox.v42.models.Entity
       id: 8
       name: Comms closet
@@ -1391,6 +1413,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Rochester
       url: http://localhost:8042/api/dcim/sites/9/
       slug: dm-rochester
+    location: null
     rack: !!python/object:annetbox.v42.models.Entity
       id: 8
       name: Comms closet
@@ -1450,6 +1473,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Rochester
       url: http://localhost:8042/api/dcim/sites/9/
       slug: dm-rochester
+    location: null
     rack: !!python/object:annetbox.v42.models.Entity
       id: 8
       name: Comms closet
@@ -1509,6 +1533,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Scranton
       url: http://localhost:8042/api/dcim/sites/10/
       slug: dm-scranton
+    location: null
     rack: !!python/object:annetbox.v42.models.Entity
       id: 9
       name: Comms closet
@@ -1573,6 +1598,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Scranton
       url: http://localhost:8042/api/dcim/sites/10/
       slug: dm-scranton
+    location: null
     rack: !!python/object:annetbox.v42.models.Entity
       id: 9
       name: Comms closet
@@ -1632,6 +1658,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Scranton
       url: http://localhost:8042/api/dcim/sites/10/
       slug: dm-scranton
+    location: null
     rack: !!python/object:annetbox.v42.models.Entity
       id: 9
       name: Comms closet
@@ -1691,6 +1718,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Stamford
       url: http://localhost:8042/api/dcim/sites/11/
       slug: dm-stamford
+    location: null
     rack: !!python/object:annetbox.v42.models.Entity
       id: 10
       name: Comms closet
@@ -1755,6 +1783,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Stamford
       url: http://localhost:8042/api/dcim/sites/11/
       slug: dm-stamford
+    location: null
     rack: !!python/object:annetbox.v42.models.Entity
       id: 10
       name: Comms closet
@@ -1814,6 +1843,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Stamford
       url: http://localhost:8042/api/dcim/sites/11/
       slug: dm-stamford
+    location: null
     rack: !!python/object:annetbox.v42.models.Entity
       id: 10
       name: Comms closet

--- a/tests/integration/fixtures/v42/dcim_device_01/expected.yaml
+++ b/tests/integration/fixtures/v42/dcim_device_01/expected.yaml
@@ -52,6 +52,7 @@ output: !!python/object:annetbox.v42.models.Device
     display: DM-Akron
     url: http://localhost:8042/api/dcim/sites/2/
     slug: dm-akron
+  location: null
   rack: !!python/object:annetbox.v42.models.Entity
     id: 1
     name: Comms closet

--- a/tests/integration/fixtures/v42/dcim_devices_01/expected.yaml
+++ b/tests/integration/fixtures/v42/dcim_devices_01/expected.yaml
@@ -53,6 +53,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Akron
       url: http://localhost:8042/api/dcim/sites/2/
       slug: dm-akron
+    location: null
     rack: !!python/object:annetbox.v42.models.Entity
       id: 1
       name: Comms closet
@@ -117,6 +118,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Akron
       url: http://localhost:8042/api/dcim/sites/2/
       slug: dm-akron
+    location: null
     rack: !!python/object:annetbox.v42.models.Entity
       id: 1
       name: Comms closet
@@ -176,6 +178,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Akron
       url: http://localhost:8042/api/dcim/sites/2/
       slug: dm-akron
+    location: null
     rack: !!python/object:annetbox.v42.models.Entity
       id: 1
       name: Comms closet
@@ -235,6 +238,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Albany
       url: http://localhost:8042/api/dcim/sites/3/
       slug: dm-albany
+    location: null
     rack: !!python/object:annetbox.v42.models.Entity
       id: 2
       name: Comms closet
@@ -299,6 +303,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Albany
       url: http://localhost:8042/api/dcim/sites/3/
       slug: dm-albany
+    location: null
     rack: !!python/object:annetbox.v42.models.Entity
       id: 2
       name: Comms closet
@@ -358,6 +363,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Albany
       url: http://localhost:8042/api/dcim/sites/3/
       slug: dm-albany
+    location: null
     rack: !!python/object:annetbox.v42.models.Entity
       id: 2
       name: Comms closet
@@ -417,6 +423,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Binghamton
       url: http://localhost:8042/api/dcim/sites/4/
       slug: dm-binghamton
+    location: null
     rack: !!python/object:annetbox.v42.models.Entity
       id: 3
       name: Comms closet
@@ -481,6 +488,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Binghamton
       url: http://localhost:8042/api/dcim/sites/4/
       slug: dm-binghamton
+    location: null
     rack: !!python/object:annetbox.v42.models.Entity
       id: 3
       name: Comms closet
@@ -540,6 +548,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Binghamton
       url: http://localhost:8042/api/dcim/sites/4/
       slug: dm-binghamton
+    location: null
     rack: !!python/object:annetbox.v42.models.Entity
       id: 3
       name: Comms closet
@@ -599,6 +608,7 @@ output: !!python/object:annetbox.base.models.PagingResponse
       display: DM-Buffalo
       url: http://localhost:8042/api/dcim/sites/5/
       slug: dm-buffalo
+    location: null
     rack: !!python/object:annetbox.v42.models.Entity
       id: 4
       name: Comms closet

--- a/tests/integration/fixtures/v42/dcim_site_01/expected.yaml
+++ b/tests/integration/fixtures/v42/dcim_site_01/expected.yaml
@@ -28,3 +28,18 @@ output: !!python/object:annetbox.v42.models.Site
   custom_fields: {}
   created: 2021-04-02 00:00:00+00:00
   last_updated: 2021-12-30 15:45:37.371000+00:00
+  region: !!python/object:annetbox.v42.models.RegionBrief
+    id: 40
+    name: North Carolina
+    display: North Carolina
+    url: http://localhost:8042/api/dcim/regions/40/
+    slug: us-nc
+    description: ''
+  group: null
+  tenant: !!python/object:annetbox.v42.models.TenantBrief
+    id: 13
+    name: NC State University
+    display: NC State University
+    url: http://localhost:8042/api/tenancy/tenants/13/
+    slug: nc-state
+    description: ''

--- a/tests/integration/fixtures/v42/dcim_sites_01/expected.yaml
+++ b/tests/integration/fixtures/v42/dcim_sites_01/expected.yaml
@@ -29,6 +29,21 @@ output: !!python/object:annetbox.base.models.PagingResponse
     custom_fields: {}
     created: 2021-04-02 00:00:00+00:00
     last_updated: 2021-12-30 15:45:37.371000+00:00
+    region: !!python/object:annetbox.v42.models.RegionBrief
+      id: 40
+      name: North Carolina
+      display: North Carolina
+      url: http://localhost:8042/api/dcim/regions/40/
+      slug: us-nc
+      description: ''
+    group: null
+    tenant: !!python/object:annetbox.v42.models.TenantBrief
+      id: 13
+      name: NC State University
+      display: NC State University
+      url: http://localhost:8042/api/tenancy/tenants/13/
+      slug: nc-state
+      description: ''
   - !!python/object:annetbox.v42.models.Site
     id: 22
     name: D. S. Weaver Labs
@@ -41,6 +56,21 @@ output: !!python/object:annetbox.base.models.PagingResponse
     custom_fields: {}
     created: 2021-04-02 00:00:00+00:00
     last_updated: 2021-12-30 15:45:37.549000+00:00
+    region: !!python/object:annetbox.v42.models.RegionBrief
+      id: 40
+      name: North Carolina
+      display: North Carolina
+      url: http://localhost:8042/api/dcim/regions/40/
+      slug: us-nc
+      description: ''
+    group: null
+    tenant: !!python/object:annetbox.v42.models.TenantBrief
+      id: 13
+      name: NC State University
+      display: NC State University
+      url: http://localhost:8042/api/tenancy/tenants/13/
+      slug: nc-state
+      description: ''
   - !!python/object:annetbox.v42.models.Site
     id: 2
     name: DM-Akron
@@ -53,6 +83,27 @@ output: !!python/object:annetbox.base.models.PagingResponse
     custom_fields: {}
     created: 2020-12-19 00:00:00+00:00
     last_updated: 2021-12-30 15:45:37.384000+00:00
+    region: !!python/object:annetbox.v42.models.RegionBrief
+      id: 51
+      name: Ohio
+      display: Ohio
+      url: http://localhost:8042/api/dcim/regions/51/
+      slug: us-oh
+      description: ''
+    group: !!python/object:annetbox.v42.models.SiteGroupBrief
+      id: 2
+      name: Branch Offices
+      display: Branch Offices
+      url: http://localhost:8042/api/dcim/site-groups/2/
+      slug: branch-offices
+      description: ''
+    tenant: !!python/object:annetbox.v42.models.TenantBrief
+      id: 5
+      name: Dunder-Mifflin, Inc.
+      display: Dunder-Mifflin, Inc.
+      url: http://localhost:8042/api/tenancy/tenants/5/
+      slug: dunder-mifflin
+      description: ''
   - !!python/object:annetbox.v42.models.Site
     id: 3
     name: DM-Albany
@@ -65,6 +116,27 @@ output: !!python/object:annetbox.base.models.PagingResponse
     custom_fields: {}
     created: 2020-12-19 00:00:00+00:00
     last_updated: 2021-12-30 15:45:37.397000+00:00
+    region: !!python/object:annetbox.v42.models.RegionBrief
+      id: 43
+      name: New York
+      display: New York
+      url: http://localhost:8042/api/dcim/regions/43/
+      slug: us-ny
+      description: ''
+    group: !!python/object:annetbox.v42.models.SiteGroupBrief
+      id: 2
+      name: Branch Offices
+      display: Branch Offices
+      url: http://localhost:8042/api/dcim/site-groups/2/
+      slug: branch-offices
+      description: ''
+    tenant: !!python/object:annetbox.v42.models.TenantBrief
+      id: 5
+      name: Dunder-Mifflin, Inc.
+      display: Dunder-Mifflin, Inc.
+      url: http://localhost:8042/api/tenancy/tenants/5/
+      slug: dunder-mifflin
+      description: ''
   - !!python/object:annetbox.v42.models.Site
     id: 4
     name: DM-Binghamton
@@ -77,3 +149,24 @@ output: !!python/object:annetbox.base.models.PagingResponse
     custom_fields: {}
     created: 2020-12-19 00:00:00+00:00
     last_updated: 2021-12-30 15:45:37.409000+00:00
+    region: !!python/object:annetbox.v42.models.RegionBrief
+      id: 43
+      name: New York
+      display: New York
+      url: http://localhost:8042/api/dcim/regions/43/
+      slug: us-ny
+      description: ''
+    group: !!python/object:annetbox.v42.models.SiteGroupBrief
+      id: 2
+      name: Branch Offices
+      display: Branch Offices
+      url: http://localhost:8042/api/dcim/site-groups/2/
+      slug: branch-offices
+      description: ''
+    tenant: !!python/object:annetbox.v42.models.TenantBrief
+      id: 5
+      name: Dunder-Mifflin, Inc.
+      display: Dunder-Mifflin, Inc.
+      url: http://localhost:8042/api/tenancy/tenants/5/
+      slug: dunder-mifflin
+      description: ''

--- a/tests/integration/fixtures/v42/lock.yaml
+++ b/tests/integration/fixtures/v42/lock.yaml
@@ -44,7 +44,7 @@ test_cases:
   - path: cassette.yaml
     sha256: 64665de1f577d68b50d2f13e85217536c635537b8f0363fb9e72e6e3d1e957fd
   - path: expected.yaml
-    sha256: a6e002644c1e69eb031ab710d25735690726c7b923ecd676bcf71ff016a0dff1
+    sha256: 9886df6cbe56cac884993c7da666231763ae67b3e0c5d2a4c805252fac0d0503
 - test_case: dcim_all_interfaces_01
   files:
   - path: cassette.yaml
@@ -74,13 +74,13 @@ test_cases:
   - path: cassette.yaml
     sha256: c039720b9aecd9943bd28ce21ef0f14305eadf6d6825b0d8bcf26eb3e83238af
   - path: expected.yaml
-    sha256: 0a750100951c9637fc1e4968e5317e1670fd7ce8eee4b9f341d48764e5039519
+    sha256: 0675c1d3b5c608f371fe7c09fc80c0a3fde4a10aa9d4cf427768415bb288f18d
 - test_case: dcim_devices_01
   files:
   - path: cassette.yaml
     sha256: 8b5aebe114836ce94cad568ad465f05ff0ea951a0260142c3a4a9dab81cc30ff
   - path: expected.yaml
-    sha256: 9ebcab90a6709ad1688eda13a7a71eda9e53d92596cf1096f42cce36ca7e239c
+    sha256: 8de260eb8d13359ef7d098155236c2a04cf6e72ded52b5054ce01b82cd0a7e73
 - test_case: dcim_interface_trace_01
   files:
   - path: cassette.yaml
@@ -128,7 +128,7 @@ test_cases:
   - path: cassette.yaml
     sha256: 56f849722861fb5a0f68c6b58d156e5e103f8beb084a369baf0873ad4346abe7
   - path: expected.yaml
-    sha256: e957cb14ca8051ecd5562183fad1c114fe1dbbf2d07a2c62a7975552096fa7af
+    sha256: d79ba6f933818d640a6e37655a4f442a589dd3f03b9c1421b74229927ae6a3d3
 - test_case: dcim_site_group_01
   files:
   - path: cassette.yaml
@@ -146,7 +146,7 @@ test_cases:
   - path: cassette.yaml
     sha256: 6459582bfbf6320011a0ee14cecf76e9c270f944550efeb61caa0ece598907b1
   - path: expected.yaml
-    sha256: ede96f17e9a8ae662bd6ce97020d81e73b1a603c707d96b48405d250fbe966cb
+    sha256: 5698473968eb67a0bd715e1592644bf2b768351bb90b2100c24d6e156b0857ed
 - test_case: ipam_all_ip_addresses_01
   files:
   - path: cassette.yaml
@@ -176,7 +176,7 @@ test_cases:
   - path: cassette.yaml
     sha256: c15735df83474e734c64b6f3b3745084b36b0355e11c5feed738db166eae0d2f
   - path: expected.yaml
-    sha256: 1689eeb47a8591c5aa025839c7a68d0cc4e27006684ae5f4f6009290fc31fdcf
+    sha256: 33d497bb91f47f092ebdcb2dda767215f11e78d3c7c41828df69bd21f870ecb1
 - test_case: tenancy_tenant_group_01
   files:
   - path: cassette.yaml
@@ -194,5 +194,5 @@ test_cases:
   - path: cassette.yaml
     sha256: bf42c75ed0e8ca23aa9c365aba48b7793407e174174ea95c0faecc40c36dc326
   - path: expected.yaml
-    sha256: c8127d589ccd67b15793ed2fe40babc15e18094865d0e5bd25b5fc8059699fda
-sha256: b76958500fe8fb0e20b32fcaac2a91602af035f19a3c87968b4640c7dbaa5eba
+    sha256: 48c1c02fe57c79eef48063dcbaf530f25d26e73673e9cd7e95c9a5b1fbd07375
+sha256: 7d7f045ddc21df3895274974d1b9be9f733e96aea10f58c2fab64d3fbf2840eb

--- a/tests/integration/fixtures/v42/tenancy_tenant_01/expected.yaml
+++ b/tests/integration/fixtures/v42/tenancy_tenant_01/expected.yaml
@@ -29,9 +29,10 @@ output: !!python/object:annetbox.v42.models.Tenant
     cust_id: CYB01
   created: 2020-12-19 00:00:00+00:00
   last_updated: 2020-12-30 18:43:27.449000+00:00
-  group: !!python/object:annetbox.v42.models.EntityWithSlug
+  group: !!python/object:annetbox.v42.models.TenantGroupBrief
     id: 1
     name: Customers
     display: Customers
     url: http://localhost:8042/api/tenancy/tenant-groups/1/
     slug: customers
+    description: ''

--- a/tests/integration/fixtures/v42/tenancy_tenants_01/expected.yaml
+++ b/tests/integration/fixtures/v42/tenancy_tenants_01/expected.yaml
@@ -30,12 +30,13 @@ output: !!python/object:annetbox.base.models.PagingResponse
       cust_id: CYB01
     created: 2020-12-19 00:00:00+00:00
     last_updated: 2020-12-30 18:43:27.449000+00:00
-    group: !!python/object:annetbox.v42.models.EntityWithSlug
+    group: !!python/object:annetbox.v42.models.TenantGroupBrief
       id: 1
       name: Customers
       display: Customers
       url: http://localhost:8042/api/tenancy/tenant-groups/1/
       slug: customers
+      description: ''
   - !!python/object:annetbox.v42.models.Tenant
     id: 5
     name: Dunder-Mifflin, Inc.
@@ -49,12 +50,13 @@ output: !!python/object:annetbox.base.models.PagingResponse
       cust_id: DMI01
     created: 2020-12-19 00:00:00+00:00
     last_updated: 2020-12-30 18:43:27.515000+00:00
-    group: !!python/object:annetbox.v42.models.EntityWithSlug
+    group: !!python/object:annetbox.v42.models.TenantGroupBrief
       id: 1
       name: Customers
       display: Customers
       url: http://localhost:8042/api/tenancy/tenant-groups/1/
       slug: customers
+      description: ''
   - !!python/object:annetbox.v42.models.Tenant
     id: 1
     name: Initech
@@ -68,12 +70,13 @@ output: !!python/object:annetbox.base.models.PagingResponse
       cust_id: INI04
     created: 2020-12-19 00:00:00+00:00
     last_updated: 2020-12-30 18:43:27.571000+00:00
-    group: !!python/object:annetbox.v42.models.EntityWithSlug
+    group: !!python/object:annetbox.v42.models.TenantGroupBrief
       id: 1
       name: Customers
       display: Customers
       url: http://localhost:8042/api/tenancy/tenant-groups/1/
       slug: customers
+      description: ''
   - !!python/object:annetbox.v42.models.Tenant
     id: 10
     name: Jimbob's Banking & Trust
@@ -87,12 +90,13 @@ output: !!python/object:annetbox.base.models.PagingResponse
       cust_id: ''
     created: 2021-03-10 00:00:00+00:00
     last_updated: 2021-03-10 20:44:16.078000+00:00
-    group: !!python/object:annetbox.v42.models.EntityWithSlug
+    group: !!python/object:annetbox.v42.models.TenantGroupBrief
       id: 1
       name: Customers
       display: Customers
       url: http://localhost:8042/api/tenancy/tenant-groups/1/
       slug: customers
+      description: ''
   - !!python/object:annetbox.v42.models.Tenant
     id: 9
     name: Nakatomi Corportation
@@ -106,9 +110,10 @@ output: !!python/object:annetbox.base.models.PagingResponse
       cust_id: YKY01
     created: 2020-12-19 00:00:00+00:00
     last_updated: 2020-12-30 18:43:27.631000+00:00
-    group: !!python/object:annetbox.v42.models.EntityWithSlug
+    group: !!python/object:annetbox.v42.models.TenantGroupBrief
       id: 1
       name: Customers
       display: Customers
       url: http://localhost:8042/api/tenancy/tenant-groups/1/
       slug: customers
+      description: ''


### PR DESCRIPTION
I completely missed the fact that existing dcim_sites API response model does not expose those pieces of data in the previous iteration https://github.com/annetutil/annetbox/pull/77

Summary:
   Add fields region, group, tenant to `Site`
   Add location field to `Device`
   Change type of group in `Tenant` to `TenantGroupBrief`
